### PR TITLE
chore: fix broken docstrings and reformats the code to oss line-length

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -83,7 +83,9 @@ class MeasureResult:
         return self.total_events / self.elapsed_time
 
 
-async def measure(case: BenchmarkCase, measure_time: int) -> AsyncGenerator[MeasureResult, None]:
+async def measure(
+    case: BenchmarkCase, measure_time: int
+) -> AsyncGenerator[MeasureResult, None]:
     """Run benchmark and yield results every second.
 
     Args:
@@ -98,10 +100,14 @@ async def measure(case: BenchmarkCase, measure_time: int) -> AsyncGenerator[Meas
             yield MeasureResult(-1, elapsed_time)
             await asyncio.sleep(1.0)
 
-    yield MeasureResult(case.get_total_processed_msgs(), time.time() - start_time)
+    yield MeasureResult(
+        case.get_total_processed_msgs(), time.time() - start_time
+    )
 
 
-async def run_benchmark(case: BenchmarkCase, measure_time: int) -> MeasureResult:
+async def run_benchmark(
+    case: BenchmarkCase, measure_time: int
+) -> MeasureResult:
     """Execute a benchmark with real-time progress display.
 
     Args:
@@ -185,7 +191,9 @@ def save_results(
         )
 
 
-def print_results(cases_results: list[tuple[BenchmarkCase, MeasureResult]]) -> None:
+def print_results(
+    cases_results: list[tuple[BenchmarkCase, MeasureResult]],
+) -> None:
     """Print formatted benchmark results table.
 
     Args:
@@ -206,7 +214,9 @@ def print_results(cases_results: list[tuple[BenchmarkCase, MeasureResult]]) -> N
     print("-" * 60)
 
     # Calculate overhead for each test case against baseline.
-    baseline_result = next((r for c, r in cases_results if c.case_name == "baseline"), None)
+    baseline_result = next(
+        (r for c, r in cases_results if c.case_name == "baseline"), None
+    )
     if not baseline_result or baseline_result.eps <= 0:
         return
 
@@ -251,7 +261,9 @@ Examples:
 
     args = parser.parse_args()
 
-    cases_cls: list[Any] = cast(list[Any], BENCH_CASE_IMPLEMENTATIONS.get(args.case, []))
+    cases_cls: list[Any] = cast(
+        list[Any], BENCH_CASE_IMPLEMENTATIONS.get(args.case, [])
+    )
     if not cases_cls:
         raise ValueError(f"No benchmark found for --case {args.case}")
 

--- a/benchmarks/cases/baseline.py
+++ b/benchmarks/cases/baseline.py
@@ -82,7 +82,9 @@ class BaselinePubSubTestCase:
         Returns:
             str: The subscription path.
         """
-        subscription_path: str = SubscriberClient.subscription_path(PROJECT_ID, SUBSCRIPTION_NAME)
+        subscription_path: str = SubscriberClient.subscription_path(
+            PROJECT_ID, SUBSCRIPTION_NAME
+        )
 
         with suppress(AlreadyExists):
             self._subscriber_client.create_subscription(  # type: ignore[union-attr]

--- a/docs/snippets/advanced/e1_01_custom_middlewares.py
+++ b/docs/snippets/advanced/e1_01_custom_middlewares.py
@@ -94,10 +94,16 @@ class ErrorHandlingMiddleware(BaseMiddleware):
         try:
             return await super().on_message(message)
         except ValueError as error:
-            logger.warning("Dropping message due to validation error", extra={"error": str(error)})
+            logger.warning(
+                "Dropping message due to validation error",
+                extra={"error": str(error)},
+            )
             raise Drop(str(error)) from error
         except TimeoutError as error:
-            logger.info("Retrying message due to transient timeout", extra={"error": str(error)})
+            logger.info(
+                "Retrying message due to transient timeout",
+                extra={"error": str(error)},
+            )
             raise Retry(str(error)) from error
 
 

--- a/docs/snippets/advanced/e1_02_dlt.py
+++ b/docs/snippets/advanced/e1_02_dlt.py
@@ -109,7 +109,9 @@ class FallbackPaymentService:
 
 
 class AdminDashboard:
-    async def create_ticket(self, title: str, data: bytes, priority: str) -> None:
+    async def create_ticket(
+        self, title: str, data: bytes, priority: str
+    ) -> None:
         pass
 
 

--- a/docs/snippets/advanced/e1_03_filters.py
+++ b/docs/snippets/advanced/e1_03_filters.py
@@ -47,11 +47,16 @@ async def handle_orders(message: Message):
 
 
 # --8<-- [start:filter_and]
+FILTER_EXP_PREMIUM = (
+    'attributes.priority = "high" AND attributes.customer_tier = "premium"'
+)
+
+
 @broker.subscriber(
     alias="premium-urgent",
     topic_name="tickets",
     subscription_name="premium-urgent-subscription",
-    filter_expression='attributes.priority = "high" AND attributes.customer_tier = "premium"',
+    filter_expression=FILTER_EXP_PREMIUM,
 )
 async def handle_premium_urgent(message: Message):
     # Only receives high-priority tickets from premium customers
@@ -62,11 +67,16 @@ async def handle_premium_urgent(message: Message):
 
 
 # --8<-- [start:filter_or]
+FILTER_EXP_ALERTS = (
+    'attributes.severity = "critical" OR attributes.severity = "high"'
+)
+
+
 @broker.subscriber(
     alias="critical-alerts",
     topic_name="alerts",
     subscription_name="critical-alerts-subscription",
-    filter_expression='attributes.severity = "critical" OR attributes.severity = "high"',
+    filter_expression=FILTER_EXP_ALERTS,
 )
 async def handle_critical_alerts(message: Message):
     # Receives both critical and high severity alerts

--- a/docs/snippets/advanced/e1_04_ordering.py
+++ b/docs/snippets/advanced/e1_04_ordering.py
@@ -44,9 +44,10 @@ async def user_action():
         attributes={"user_id": "user-123"},
     )
 
+    # Guaranteed to be processed after the login message
     await ordered_publisher.publish(
         data={"action": "update_profile", "user_id": "user-123"},
-        ordering_key="user-123",  # Guaranteed to be processed after the login message
+        ordering_key="user-123",
         attributes={"user_id": "user-123"},
     )
 

--- a/docs/snippets/advanced/e1_05_delivery_guarantees.py
+++ b/docs/snippets/advanced/e1_05_delivery_guarantees.py
@@ -98,7 +98,9 @@ async def db_idempotent_handler(message: Message):
 
     # Use database transaction with unique constraint
     try:
-        await db.execute("INSERT INTO processed_orders (order_id) VALUES (?)", [order_id])
+        await db.execute(
+            "INSERT INTO processed_orders (order_id) VALUES (?)", [order_id]
+        )
     except UniqueViolationError:
         return  # Already processed
 
@@ -110,7 +112,9 @@ async def db_idempotent_handler(message: Message):
 
 # Simulated Redis for idempotency
 class Redis:
-    async def set(self, key: str, value: str, nx: bool = False, ex: int = 0) -> bool:
+    async def set(
+        self, key: str, value: str, nx: bool = False, ex: int = 0
+    ) -> bool:
         return True
 
 

--- a/docs/snippets/advanced/e1_07_multiple_projects.py
+++ b/docs/snippets/advanced/e1_07_multiple_projects.py
@@ -66,7 +66,9 @@ async def handle_cross_project_events(message: Message):
 local_publisher = broker.publisher("local-events")
 
 # Publisher for a different project
-cross_project_publisher = broker.publisher("shared-events", project_id="project-b")
+cross_project_publisher = broker.publisher(
+    "shared-events", project_id="project-b"
+)
 
 
 @app.post("/send-event")

--- a/docs/snippets/basic_usage/e0_01_first_steps.py
+++ b/docs/snippets/basic_usage/e0_01_first_steps.py
@@ -12,7 +12,6 @@ class Address(BaseModel):
 
 # --8<-- [end:pydantic_model]
 
-
 # --8<-- [start:broker_app]
 broker = PubSubBroker(project_id="your-project-id")
 app = FastPubSub(broker)

--- a/docs/snippets/basic_usage/e2_03_message_formats.py
+++ b/docs/snippets/basic_usage/e2_03_message_formats.py
@@ -31,7 +31,9 @@ async def handle(message: Message) -> None:
 @app.after_startup
 async def publish_initial_messages() -> None:
     message = TestMessage(
-        event="checkout", source="checkout-cart", message="the user put a item to the cart"
+        event="checkout",
+        source="checkout-cart",
+        message="the user put a item to the cart",
     )
 
     publisher: Publisher = broker.publisher("test-topic-pydantic")

--- a/docs/snippets/basic_usage/e2_05_publish_with_attributes.py
+++ b/docs/snippets/basic_usage/e2_05_publish_with_attributes.py
@@ -1,25 +1,3 @@
-"""Title: Publishing with Attributes
-
-Demonstrates publishing messages with custom attributes for metadata.
-
-This example shows:
-- Adding attributes to messages via broker.publish()
-- Adding attributes via Publisher object
-- Using attributes for server-side filtering
-- Adding routing and context information to messages
-
-Attributes are key-value string pairs that appear in the message metadata,
-separate from the message payload. Useful for filtering and routing.
-
-Run with:
-    fastpubsub run docs.snippets.basic_usage.e2_06_publish_with_attributes:app
-
-Requirements:
-    - Set PUBSUB_EMULATOR_HOST for local testing, or
-    - Set GOOGLE_APPLICATION_CREDENTIALS for GCP
-"""
-
-# --8<-- [start:publish_attributes_full]
 from fastpubsub import FastPubSub, Message, Publisher, PubSubBroker
 from fastpubsub.logger import logger
 
@@ -63,4 +41,3 @@ async def publish_with_publisher() -> None:
 
 
 # --8<-- [end:publish_attributes_publisher]
-# --8<-- [end:publish_attributes_full]

--- a/docs/snippets/middlewares/e1_01_common_middlewares.py
+++ b/docs/snippets/middlewares/e1_01_common_middlewares.py
@@ -18,7 +18,10 @@ app = FastPubSub(broker)
     subscription_name="gzipped_sub",
 )
 async def broker_gzip_message(message: Message) -> None:
-    logger.info(f"We received message with encoding {message.attributes['content-encoding']}")
+    logger.info(
+        "We received message with encoding "
+        f"{message.attributes['content-encoding']}"
+    )
 
 
 @app.after_startup

--- a/docs/snippets/middlewares/e4_01_full_logging_middleware.py
+++ b/docs/snippets/middlewares/e4_01_full_logging_middleware.py
@@ -1,7 +1,13 @@
 import time
 from typing import Any
 
-from fastpubsub import BaseMiddleware, FastPubSub, Message, Middleware, PubSubBroker
+from fastpubsub import (
+    BaseMiddleware,
+    FastPubSub,
+    Message,
+    Middleware,
+    PubSubBroker,
+)
 from fastpubsub.logger import logger
 
 

--- a/docs/snippets/middlewares/e4_02_broker_level_middleware.py
+++ b/docs/snippets/middlewares/e4_02_broker_level_middleware.py
@@ -1,6 +1,12 @@
 from typing import Any
 
-from fastpubsub import BaseMiddleware, FastPubSub, Message, Middleware, PubSubBroker
+from fastpubsub import (
+    BaseMiddleware,
+    FastPubSub,
+    Message,
+    Middleware,
+    PubSubBroker,
+)
 from fastpubsub.logger import logger
 
 

--- a/docs/snippets/middlewares/e4_04_subscriber_level_middleware.py
+++ b/docs/snippets/middlewares/e4_04_subscriber_level_middleware.py
@@ -1,6 +1,12 @@
 from typing import Any
 
-from fastpubsub import BaseMiddleware, FastPubSub, Message, Middleware, PubSubBroker
+from fastpubsub import (
+    BaseMiddleware,
+    FastPubSub,
+    Message,
+    Middleware,
+    PubSubBroker,
+)
 from fastpubsub.logger import logger
 
 

--- a/docs/snippets/observability/e1_01_logging_basics.py
+++ b/docs/snippets/observability/e1_01_logging_basics.py
@@ -26,7 +26,8 @@ async def handle_task(message: Message):
 )
 async def handle_order(message: Message):
     logger.info("Processing order")
-    # Output: Processing order | name=order-handler message_id=12345 topic_name=orders
+    # Output:
+    # Processing order | name=order-handler message_id=12345 topic_name=orders
 
 
 # --8<-- [end:context_aware_logging]

--- a/docs/snippets/routers/e1_01_prefix_resolution.py
+++ b/docs/snippets/routers/e1_01_prefix_resolution.py
@@ -1,24 +1,3 @@
-"""Title: Prefix Resolution with Unique Aliases
-
-Demonstrates that routers with empty prefixes can coexist when aliases are unique.
-
-This example shows:
-- Creating multiple routers with empty prefixes ("")
-- Using different aliases for each subscriber to avoid conflicts
-- How prefix resolution works when no prefix is specified
-
-When using empty prefixes, you must ensure that all subscriber aliases are
-globally unique, as there's no prefix to differentiate them.
-
-Run with:
-    fastpubsub run examples.routers.e1_03_prefix_resolution:app
-
-Requirements:
-    - Set PUBSUB_EMULATOR_HOST for local testing, or
-    - Set GOOGLE_APPLICATION_CREDENTIALS for GCP
-"""
-
-# --8<-- [start:prefix_resolution_full]
 from fastpubsub.applications import FastPubSub
 from fastpubsub.broker import PubSubBroker
 from fastpubsub.datastructures import Message
@@ -63,6 +42,3 @@ async def other_unnamed_router_handler(message: Message) -> None:
 @app.after_startup
 async def test_publish() -> None:
     await broker.publish("test-router-topic", {"hello": "world"})
-
-
-# --8<-- [end:prefix_resolution_full]

--- a/docs/snippets/routers/e1_03_router_middlewares.py
+++ b/docs/snippets/routers/e1_03_router_middlewares.py
@@ -1,21 +1,3 @@
-"""Title: Router with Middlewares
-
-Demonstrates applying middlewares to all subscribers in a router.
-
-This example shows:
-- Creating a router with middlewares
-- All subscribers in the router automatically get the middlewares applied
-- Using Middleware wrapper to pass configuration
-
-Run with:
-    fastpubsub run docs.snippets.routers.e1_06_router_middlewares:app
-
-Requirements:
-    - Set PUBSUB_EMULATOR_HOST for local testing, or
-    - Set GOOGLE_APPLICATION_CREDENTIALS for GCP
-"""
-
-# --8<-- [start:router_middlewares_full]
 from typing import Any
 
 from fastpubsub import (
@@ -76,6 +58,3 @@ app = FastPubSub(broker)
 @app.after_startup
 async def publish_test():
     await users_router.publish("users-topic", {"user": "test"})
-
-
-# --8<-- [end:router_middlewares_full]

--- a/docs/snippets/troubleshooting/e1_02_performance_patterns.py
+++ b/docs/snippets/troubleshooting/e1_02_performance_patterns.py
@@ -1,27 +1,12 @@
-"""Title: Performance Troubleshooting Patterns
-
-Demonstrates performance optimization patterns.
-
-This example shows:
-- Increasing max_messages for throughput
-- Profiling middleware
-- Limiting concurrent messages
-- Memory leak prevention
-- Shutdown timeout configuration
-- Message ordering
-
-Run with:
-    fastpubsub run docs.snippets.troubleshooting.e1_02_performance_patterns:app
-
-Requirements:
-    - Set PUBSUB_EMULATOR_HOST for local testing, or
-    - Set GOOGLE_APPLICATION_CREDENTIALS for GCP
-"""
-
-# --8<-- [start:performance_full]
 import time
 
-from fastpubsub import BaseMiddleware, FastPubSub, Message, Middleware, PubSubBroker
+from fastpubsub import (
+    BaseMiddleware,
+    FastPubSub,
+    Message,
+    Middleware,
+    PubSubBroker,
+)
 from fastpubsub.logger import logger
 
 
@@ -108,4 +93,3 @@ async def ordered_handler(message: Message):
 
 
 # --8<-- [end:ordered_handler]
-# --8<-- [end:performance_full]

--- a/fastpubsub/__about__.py
+++ b/fastpubsub/__about__.py
@@ -3,5 +3,3 @@
 from importlib.metadata import version
 
 __version__ = version("fastpubsub")
-
-SERVICE_NAME = f"fastpubsub-{__version__}"

--- a/fastpubsub/__init__.py
+++ b/fastpubsub/__init__.py
@@ -1,4 +1,4 @@
-"""A high performance FastAPI-based message consumer framework for Google PubSub."""
+"""A high performance async message consumer framework for Google PubSub."""
 
 from fastpubsub.applications import FastPubSub
 from fastpubsub.broker import PubSubBroker

--- a/fastpubsub/applications.py
+++ b/fastpubsub/applications.py
@@ -183,8 +183,12 @@ class FastPubSub(FastAPI, Application):
             after_shutdown=after_shutdown,
         )
 
-        self.add_api_route(path=liveness_url, endpoint=self._get_liveness, methods=["GET"])
-        self.add_api_route(path=readiness_url, endpoint=self._get_readiness, methods=["GET"])
+        self.add_api_route(
+            path=liveness_url, endpoint=self._get_liveness, methods=["GET"]
+        )
+        self.add_api_route(
+            path=readiness_url, endpoint=self._get_readiness, methods=["GET"]
+        )
 
     @asynccontextmanager
     async def _run(self, app: "FastPubSub") -> AsyncGenerator[None]:

--- a/fastpubsub/broker.py
+++ b/fastpubsub/broker.py
@@ -40,15 +40,25 @@ class PubSubBroker:
             middlewares: A sequence of middlewares to apply to all messages
                 incoming to subscribers and publishers.
         """
-        if not (project_id and isinstance(project_id, str) and len(project_id.strip()) > 0):
-            raise FastPubSubException(f"The project id value ({project_id}) is invalid.")
+        if not (
+            project_id
+            and isinstance(project_id, str)
+            and len(project_id.strip()) > 0
+        ):
+            raise FastPubSubException(
+                f"The project id value ({project_id}) is invalid."
+            )
 
         self.project_id = project_id
         self.shutdown_timeout = shutdown_timeout
-        self.router = PubSubRouter(routers=routers, project_id=project_id, middlewares=middlewares)
+        self.router = PubSubRouter(
+            routers=routers, project_id=project_id, middlewares=middlewares
+        )
         self.task_manager = AsyncTaskManager()
 
-    @validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
+    @validate_call(
+        config=ConfigDict(strict=True, arbitrary_types_allowed=True)
+    )
     def subscriber(
         self,
         alias: str,
@@ -75,25 +85,32 @@ class PubSubBroker:
             alias: A unique name for the subscriber. You can use this alias to
                 select which subscription to use on the CLI.
             topic_name: The name of the topic to subscribe to.
-            subscription_name: The name of the subscription attached to the topic.
+            subscription_name: The name of the subscription for the topic.
             project_id: An alternative project id to create a subscription
                 and consume messages from. If set the broker project id
                 will be ignored.
-            autocreate: Whether to automatically create the topic and
+            autocreate: Automatically creates the topic and
                 subscription if they do not exists.
-            autoupdate: Whether to automatically update the subscription.
+            autoupdate: Automatically updates the subscription.
             filter_expression: A filter expression to apply to the
                 subscription to filter messages.
             dead_letter_topic: The name of the dead-letter topic.
             max_delivery_attempts: The maximum number of delivery attempts
                 before sending the message to the dead-letter.
             ack_deadline_seconds: The acknowledgment deadline in seconds.
-            enable_message_ordering: Whether the message must be delivered in order.
-            enable_exactly_once_delivery: Whether to enable exactly-once delivery.
+            enable_message_ordering: Enables message ordering.
+                It can only be set when creating the subscription.
+            enable_exactly_once_delivery: Enables exactly-once delivery.
+                It can only be set when creating the subscription.
             min_backoff_delay_secs: The minimum backoff delay in seconds.
             max_backoff_delay_secs: The maximum backoff delay in seconds.
-            max_messages: The maximum number of messages to fetch from the broker.
-            middlewares: A sequence of middlewares to apply **only to the subscriber**.
+            max_messages: The maximum number of messages to fetch from
+                the broker at a time.
+            middlewares: A sequence of middlewares to apply to the subscriber.
+                It is subscriber specific, not application-wide.
+
+        Returns:
+            A decorator that registers the function as a subscriber.
 
         Returns:
             A decorator that registers the function as a subscriber.
@@ -129,7 +146,9 @@ class PubSubBroker:
         Returns:
             A publisher for the given topic.
         """
-        return self.router.publisher(topic_name=topic_name, project_id=project_id)
+        return self.router.publisher(
+            topic_name=topic_name, project_id=project_id
+        )
 
     @validate_call(config=ConfigDict(strict=True))
     async def publish(
@@ -150,7 +169,7 @@ class PubSubBroker:
                         If set the broker's project id will be ignored.
             ordering_key: The ordering key for the message.
             attributes: A dictionary of message attributes.
-            autocreate: Whether to automatically create the topic if it does not exists.
+            autocreate: Automatically creates the topic if it does not exists.
         """
         return await self.router.publish(
             topic_name=topic_name,
@@ -177,8 +196,8 @@ class PubSubBroker:
 
         Args:
             middleware: The middleware to include.
-            args: The positional arguments used on the middleware instantiation.
-            kwargs: The keyword  arguments used on the middleware instantiation.
+            args: The positional arguments used on middleware instantiation.
+            kwargs: The keyword  arguments used on middleware instantiation.
         """
         return self.router.include_middleware(middleware, *args, **kwargs)
 
@@ -188,11 +207,14 @@ class PubSubBroker:
         if not subscribers:
             logger.error("No subscriber found for running.")
             raise FastPubSubException(
-                "You must select the subscribers using --subscribers flag or run them all."
+                "You must select the subscribers using "
+                "--subscribers flag or run them all."
             )
 
         for subscriber in subscribers:
-            subscription_builder = PubSubSubscriptionBuilder(project_id=subscriber.project_id)
+            subscription_builder = PubSubSubscriptionBuilder(
+                project_id=subscriber.project_id
+            )
             await subscription_builder.build(subscriber)
             self.task_manager.create_task(subscriber)
 
@@ -206,7 +228,9 @@ class PubSubBroker:
         """
         subscribers = self.task_manager.alive()
         if not subscribers:
-            logger.info("The subscribers are not active. May be they are deactivated?")
+            logger.info(
+                "The subscribers are not active. May be they are deactivated?"
+            )
             return False
 
         for name, liveness in subscribers.items():
@@ -224,7 +248,9 @@ class PubSubBroker:
         """
         subscribers = self.task_manager.ready()
         if not subscribers:
-            logger.info("The subscribers are not active. May be they are deactivated?")
+            logger.info(
+                "The subscribers are not active. May be they are deactivated?"
+            )
             return False
 
         for name, readiness in subscribers.items():
@@ -239,16 +265,22 @@ class PubSubBroker:
         selected_subscribers = self._get_selected_subscribers()
 
         if not selected_subscribers:
-            logger.debug(f"Running all the subscribers as {list(subscribers.keys())}")
+            logger.debug(
+                f"Running all the subscribers as {list(subscribers.keys())}"
+            )
             return list(subscribers.values())
 
         found_subscribers = []
         for selected_subscriber in selected_subscribers:
             if selected_subscriber not in subscribers:
-                logger.warning(f"The '{selected_subscriber}' subscriber alias not found")
+                logger.warning(
+                    f"The '{selected_subscriber}' subscriber alias not found"
+                )
                 continue
 
-            logger.debug(f"We have found the subscriber '{selected_subscriber}'")
+            logger.debug(
+                f"We have found the subscriber '{selected_subscriber}'"
+            )
             found_subscribers.append(subscribers[selected_subscriber])
 
         return found_subscribers

--- a/fastpubsub/builder.py
+++ b/fastpubsub/builder.py
@@ -32,18 +32,25 @@ class PubSubSubscriptionBuilder:
 
     async def _create_topics(self) -> None:
         target_topic = self.subscriber.topic_name
-        await self._new_topic(topic_name=target_topic, create_default_subscription=False)
+        await self._new_topic(
+            topic_name=target_topic, create_default_subscription=False
+        )
 
         if self.subscriber.dead_letter_policy:
             target_topic = self.subscriber.dead_letter_policy.topic_name
-            await self._new_topic(topic_name=target_topic, create_default_subscription=True)
+            await self._new_topic(
+                topic_name=target_topic, create_default_subscription=True
+            )
 
-    async def _new_topic(self, topic_name: str, create_default_subscription: bool = True) -> None:
+    async def _new_topic(
+        self, topic_name: str, create_default_subscription: bool = True
+    ) -> None:
         if topic_name in self.created_topics:
             return
 
         await self.client.create_topic(
-            topic_name=topic_name, create_default_subscription=create_default_subscription
+            topic_name=topic_name,
+            create_default_subscription=create_default_subscription,
         )
         self.created_topics.add(topic_name)
 

--- a/fastpubsub/cli/main.py
+++ b/fastpubsub/cli/main.py
@@ -18,12 +18,17 @@ from fastpubsub.cli.options import (
     AppVersionOption,
     CLIContext,
 )
-from fastpubsub.cli.runner import AppConfiguration, ApplicationRunner, ServerConfiguration
+from fastpubsub.cli.runner import (
+    AppConfiguration,
+    ApplicationRunner,
+    ServerConfiguration,
+)
 from fastpubsub.cli.utils import LogLevels, ensure_pubsub_credentials
 
 app = typer.Typer(
     name="fastpubsub",
-    help="A CLI to run FastPubSub applications and interact with Pub/Sub (locally and on cloud).",
+    help="A CLI to run FastPubSub applications and "
+    "interact with Pub/Sub (locally and on cloud).",
     pretty_exceptions_short=True,
     invoke_without_command=True,
     rich_markup_mode="markdown",
@@ -60,11 +65,16 @@ def main(
     ctx: CLIContext,
     version: AppVersionOption = False,
 ) -> None:
-    """Display helpful tips when the main command is run without any subcommands."""
+    """Display helpful tips when the command is run with no subcommands."""
     if ctx.invoked_subcommand is None and not version:
         rich.print("\n[bold]Welcome to the FastPubSub CLI! ✨[/bold]")
-        rich.print("\n[dim]A CLI to run FastPubSub applications and interact with Pub/Sub.[/dim]")
-        rich.print("\n[bold]Usage[/bold]: [cyan]fastpubsub [COMMAND] [ARGS]...[/cyan]")
+        rich.print(
+            "\n[dim]A CLI to run FastPubSub applications "
+            "and interact with Pub/Sub.[/dim]"
+        )
+        rich.print(
+            "\n[bold]Usage[/bold]: [cyan]fastpubsub [COMMAND] [ARGS]...[/cyan]"
+        )
         rich.print("\n[bold]Common Commands:[/bold]")
         rich.print("  [green]run[/green]    Run a FastPubSub application.")
         rich.print("  [green]help[/green]   Get detailed help for a command.")
@@ -81,7 +91,8 @@ def main(
         import platform
 
         typer.echo(
-            f"Running FastPubSub {__version__} with {platform.python_implementation()} "
+            f"Running FastPubSub {__version__} with "
+            f"{platform.python_implementation()} "
             f"{platform.python_version()} on {platform.system()}",
         )
 
@@ -132,7 +143,9 @@ def run(
         log_level=server_log_level.lower(),
     )
 
-    application_runner = ApplicationRunner(app_configuration, server_configuration)
+    application_runner = ApplicationRunner(
+        app_configuration, server_configuration
+    )
     application_runner.setup()
     application_runner.validate()
     application_runner.run()

--- a/fastpubsub/cli/options.py
+++ b/fastpubsub/cli/options.py
@@ -56,7 +56,8 @@ AppHostOption = Annotated[
     typer.Option(
         "-h",
         "--host",
-        help="The host to serve the application on. Use '0.0.0.0' for public access.",
+        help="The host to serve the application on. "
+        "Use '0.0.0.0' for public access.",
         show_default=True,
         envvar="FASTPUBSUB_SERVER_HOST",
     ),

--- a/fastpubsub/cli/runner.py
+++ b/fastpubsub/cli/runner.py
@@ -39,7 +39,9 @@ class AppConfiguration:
 class ApplicationRunner:
     """Runs a FastPubSub application."""
 
-    def __init__(self, app_config: AppConfiguration, server_config: ServerConfiguration) -> None:
+    def __init__(
+        self, app_config: AppConfiguration, server_config: ServerConfiguration
+    ) -> None:
         """Initialized a FastPubSub application runner.
 
         Args:
@@ -52,9 +54,15 @@ class ApplicationRunner:
     def setup(self) -> None:
         """Setup a FastPubSub application environment."""
         os.environ["FASTPUBSUB_LOG_LEVEL"] = self.app_config.log_level
-        os.environ["FASTPUBSUB_ENABLE_LOG_SERIALIZE"] = str(int(self.app_config.log_serialize))
-        os.environ["FASTPUBSUB_ENABLE_LOG_COLORS"] = str(int(self.app_config.log_colorize))
-        os.environ["FASTPUBSUB_SUBSCRIBERS"] = ",".join(self.app_config.subscribers)
+        os.environ["FASTPUBSUB_ENABLE_LOG_SERIALIZE"] = str(
+            int(self.app_config.log_serialize)
+        )
+        os.environ["FASTPUBSUB_ENABLE_LOG_COLORS"] = str(
+            int(self.app_config.log_colorize)
+        )
+        os.environ["FASTPUBSUB_SUBSCRIBERS"] = ",".join(
+            self.app_config.subscribers
+        )
         configure()
 
     def validate(self) -> None:
@@ -62,7 +70,9 @@ class ApplicationRunner:
         from fastpubsub.applications import FastPubSub
         from fastpubsub.exceptions import FastPubSubCLIException
 
-        posix_path = self._translate_pypath_to_posix(pypath=self.app_config.app)
+        posix_path = self._translate_pypath_to_posix(
+            pypath=self.app_config.app
+        )
         self._resolve_application_posix_path(posix_path=posix_path)
 
         app = uvicorn.importer.import_from_string(self.app_config.app)
@@ -92,7 +102,8 @@ class ApplicationRunner:
             return Path(posix_text_path)
         except Exception as e:
             raise uvicorn.importer.ImportFromStringError(
-                f'The application path "{pypath}" must be in format "<module>:<attribute>".'
+                f'The application path "{pypath}" '
+                'must be in format "<module>:<attribute>".'
             ) from e
 
     def _resolve_application_posix_path(self, posix_path: Path) -> None:

--- a/fastpubsub/cli/utils.py
+++ b/fastpubsub/cli/utils.py
@@ -23,6 +23,7 @@ def ensure_pubsub_credentials() -> None:
     emulator_host = os.getenv("PUBSUB_EMULATOR_HOST")
     if not credentials and not emulator_host:
         raise FastPubSubCLIException(
-            "You should set either of the environment variables for authentication: "
+            "You should set either of the "
+            "environment variables for authentication: "
             "(GOOGLE_APPLICATION_CREDENTIALS, PUBSUB_EMULATOR_HOST)"
         )

--- a/fastpubsub/clients/factory.py
+++ b/fastpubsub/clients/factory.py
@@ -1,15 +1,4 @@
-"""Thread-safe factory for Pub/Sub clients with async-friendly singleton caching.
-
-This module provides a centralized factory for managing Google Cloud Pub/Sub
-client instances. It ensures efficient reuse of gRPC connections by caching
-clients based on project_id and configuration options.
-
-Key features:
-- Async-friendly locking using asyncio.Lock
-- Caches PublisherClient by (project_id, enable_ordering)
-- Caches SubscriberClient by project_id
-- Provides graceful shutdown via close_all()
-"""
+"""Factories for Pub/Sub clients."""
 
 from __future__ import annotations
 
@@ -24,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class PubSubClientFactory:
-    """Async-friendly factory for Pub/Sub clients with singleton caching.
+    """Async-safe factory for Pub/Sub clients with singleton caching.
 
     This factory ensures that only one client instance is created per unique
     combination of project_id and configuration. This follows Google's
@@ -84,8 +73,12 @@ class PubSubClientFactory:
                     f"Creating new PublisherClient for project={project_id}, "
                     f"ordering={enable_ordering}"
                 )
-                options = PublisherOptions(enable_message_ordering=enable_ordering)
-                cls._publisher_cache[key] = PublisherClient(publisher_options=options)
+                options = PublisherOptions(
+                    enable_message_ordering=enable_ordering
+                )
+                cls._publisher_cache[key] = PublisherClient(
+                    publisher_options=options
+                )
 
         return cls._publisher_cache[key]
 
@@ -107,7 +100,9 @@ class PubSubClientFactory:
         async with cls._get_lock():
             # Double-check after acquiring lock
             if project_id not in cls._subscriber_cache:
-                logger.debug(f"Creating new SubscriberClient for project={project_id}")
+                logger.debug(
+                    f"Creating new SubscriberClient for project={project_id}"
+                )
                 cls._subscriber_cache[project_id] = SubscriberClient()
 
         return cls._subscriber_cache[project_id]
@@ -127,14 +122,18 @@ class PubSubClientFactory:
                     client.transport.close()
                     logger.debug(f"Closed PublisherClient for {key}")
                 except Exception:
-                    logger.exception(f"Error closing PublisherClient for {key}")
+                    logger.exception(
+                        f"Error closing PublisherClient for {key}"
+                    )
 
             for project_id, client in cls._subscriber_cache.items():
                 try:
                     client.transport.close()
                     logger.debug(f"Closed SubscriberClient for {project_id}")
                 except Exception:
-                    logger.exception(f"Error closing SubscriberClient for {project_id}")
+                    logger.exception(
+                        f"Error closing SubscriberClient for {project_id}"
+                    )
 
             cls._publisher_cache.clear()
             cls._subscriber_cache.clear()

--- a/fastpubsub/clients/pubsub.py
+++ b/fastpubsub/clients/pubsub.py
@@ -19,7 +19,11 @@ from google.pubsub import RetryPolicy, Subscription
 from fastpubsub.clients.factory import PubSubClientFactory
 from fastpubsub.clients.scheduler import AsyncScheduler
 from fastpubsub.concurrency.utils import apply_async
-from fastpubsub.datastructures import DeadLetterPolicy, MessageDeliveryPolicy, MessageRetryPolicy
+from fastpubsub.datastructures import (
+    DeadLetterPolicy,
+    MessageDeliveryPolicy,
+    MessageRetryPolicy,
+)
 from fastpubsub.exceptions import FastPubSubException
 
 DEFAULT_PUBSUB_TIMEOUT = 20.0
@@ -49,8 +53,12 @@ class PubSubClient:
         delivery_policy: MessageDeliveryPolicy,
         dead_letter_policy: DeadLetterPolicy | None = None,
     ) -> Subscription:
-        subscriber_client = await PubSubClientFactory.get_subscriber(self.project_id)
-        name = subscriber_client.subscription_path(self.project_id, subscription_name)
+        subscriber_client = await PubSubClientFactory.get_subscriber(
+            self.project_id
+        )
+        name = subscriber_client.subscription_path(
+            self.project_id, subscription_name
+        )
         topic = subscriber_client.topic_path(self.project_id, topic_name)
 
         dlt_policy = None
@@ -65,10 +73,15 @@ class PubSubClient:
                 max_delivery_attempts=dead_letter_policy.max_delivery_attempts,
             )
 
-        min_backoff_delay = timedelta(seconds=retry_policy.min_backoff_delay_secs)
-        max_backoff_delay = timedelta(seconds=retry_policy.max_backoff_delay_secs)
+        min_backoff_delay = timedelta(
+            seconds=retry_policy.min_backoff_delay_secs
+        )
+        max_backoff_delay = timedelta(
+            seconds=retry_policy.max_backoff_delay_secs
+        )
         message_retry_policy = RetryPolicy(
-            minimum_backoff=min_backoff_delay, maximum_backoff=max_backoff_delay
+            minimum_backoff=min_backoff_delay,
+            maximum_backoff=max_backoff_delay,
         )
 
         return Subscription(
@@ -106,16 +119,24 @@ class PubSubClient:
             dead_letter_policy=dead_letter_policy,
         )
 
-        subscriber_client = await PubSubClientFactory.get_subscriber(self.project_id)
+        subscriber_client = await PubSubClientFactory.get_subscriber(
+            self.project_id
+        )
         with suppress(AlreadyExists):
-            logger.debug(f"Attempting to create subscription: {subscription_request.name}")
+            logger.debug(
+                "Attempting to create subscription: "
+                f"{subscription_request.name}"
+            )
             await apply_async(
                 subscriber_client.create_subscription,
                 request=subscription_request,
                 timeout=DEFAULT_PUBSUB_TIMEOUT,
             )
 
-            logger.debug(f"Successfully created subscription: {subscription_request.name}")
+            logger.debug(
+                "Successfully created subscription: "
+                f"{subscription_request.name}"
+            )
 
     async def update_subscription(
         self,
@@ -155,8 +176,13 @@ class PubSubClient:
         update_mask = FieldMask(paths=update_fields)
 
         try:
-            subscriber_client = await PubSubClientFactory.get_subscriber(self.project_id)
-            logger.debug(f"Attempting to update the subscription: {subscription_request.name}")
+            subscriber_client = await PubSubClientFactory.get_subscriber(
+                self.project_id
+            )
+            logger.debug(
+                "Attempting to update the subscription: "
+                f"{subscription_request.name}"
+            )
             response = await apply_async(
                 subscriber_client.update_subscription,
                 subscription=subscription_request,
@@ -164,8 +190,14 @@ class PubSubClient:
                 timeout=DEFAULT_PUBSUB_TIMEOUT,
             )
 
-            logger.debug(f"Successfully updated the subscription: {subscription_request.name}")
-            logger.debug(f"The subscription is now following the configuration: {response}")
+            logger.debug(
+                "Successfully updated "
+                f"the subscription: {subscription_request.name}"
+            )
+            logger.debug(
+                "The subscription is now "
+                f"following the configuration: {response}"
+            )
         except NotFound as e:
             raise FastPubSubException(
                 "We could not update the subscription configuration. "
@@ -176,7 +208,9 @@ class PubSubClient:
                 "option to automatically create them."
             ) from e
 
-    async def create_topic(self, topic_name: str, create_default_subscription: bool = True) -> None:
+    async def create_topic(
+        self, topic_name: str, create_default_subscription: bool = True
+    ) -> None:
         """Creates a topic.
 
         Args:
@@ -184,14 +218,22 @@ class PubSubClient:
             create_default_subscription: Whether to create a default
                 subscription for the topic.
         """
-        subscriber_client = await PubSubClientFactory.get_subscriber(self.project_id)
-        publisher_client = await PubSubClientFactory.get_publisher(self.project_id)
+        subscriber_client = await PubSubClientFactory.get_subscriber(
+            self.project_id
+        )
+        publisher_client = await PubSubClientFactory.get_publisher(
+            self.project_id
+        )
 
         with suppress(AlreadyExists):
             logger.debug(f"Creating topic '{topic_name}'.")
-            topic_path = publisher_client.topic_path(self.project_id, topic_name)
+            topic_path = publisher_client.topic_path(
+                self.project_id, topic_name
+            )
 
-            topic = await apply_async(publisher_client.create_topic, name=topic_path)
+            topic = await apply_async(
+                publisher_client.create_topic, name=topic_path
+            )
             logger.debug(f"Created topic '{topic.name}' successfully.")
 
             if not create_default_subscription:
@@ -245,7 +287,11 @@ class PubSubClient:
             )
 
             message_id = await apply_async(response.result)
-            logger.info(f"Message published for topic {topic_path} with id {message_id}")
+            logger.info(
+                "Message published for "
+                f"topic {topic_path} with "
+                f"id {message_id}"
+            )
             logger.debug(f"We sent {data!r} with metadata {attributes}")
         except Exception:
             logger.exception("Publisher failure", stacklevel=5)
@@ -258,19 +304,23 @@ class PubSubClient:
         max_messages: int,
         scheduler: AsyncScheduler,
     ) -> StreamingPullFuture:
-        """Starts the subscription listening on background given a subscription.
+        """Starts the subscription listening on background.
 
         Args:
             callback: The function called when a message is received.
             subscription_name: The name of the subscription.
             max_messages: The maximum number of messages to pull.
-            scheduler: The scheduler used to receive messages from GCP and send to callback.
+            scheduler: The object that allocates messages to callbacks.
 
         Returns:
             A future that can be used to check the progress and get the result.
         """
-        subscriber_client = await PubSubClientFactory.get_subscriber(self.project_id)
-        subscription_path = subscriber_client.subscription_path(self.project_id, subscription_name)
+        subscriber_client = await PubSubClientFactory.get_subscriber(
+            self.project_id
+        )
+        subscription_path = subscriber_client.subscription_path(
+            self.project_id, subscription_name
+        )
 
         future: StreamingPullFuture = subscriber_client.subscribe(
             callback=callback,

--- a/fastpubsub/clients/scheduler.py
+++ b/fastpubsub/clients/scheduler.py
@@ -18,21 +18,21 @@ logger = logging.getLogger(__name__)
 
 
 class AsyncScheduler(Scheduler):  # type: ignore[misc]
-    """An asyncio-based scheduler for typical I/O-bound message processing.
+    """An asyncio-based scheduler for I/O-bound message processing.
 
     It must not be shared across different SubscriberClient objects.
     """
 
     def __init__(self, loop: AbstractEventLoop) -> None:
-        """Initializes an asyncio-based schedule for typical I/O-bound message processing."""
+        """Initializes the scheduler."""
         self._loop = loop
 
         self._queue: queue.Queue[Any] = queue.Queue()
 
         # Track scheduled handles (pending callbacks not yet executed)
-        self._pending_task_creations: WeakKeyDictionary[asyncio.Handle, PubSubMessage] = (
-            WeakKeyDictionary()
-        )
+        self._pending_task_creations: WeakKeyDictionary[
+            asyncio.Handle, PubSubMessage
+        ] = WeakKeyDictionary()
 
         # Track executing tasks (running coroutines)
         self._executing_tasks: dict[int, PubSubMessage] = {}
@@ -43,13 +43,20 @@ class AsyncScheduler(Scheduler):  # type: ignore[misc]
 
     @property
     def queue(self) -> queue.Queue[Any]:
-        """A thread-safe queue for communication between callbacks and the scheduling thread."""
+        """A thread-safe queue.
+
+        It is used for for communication between
+        callbacks and the scheduling thread.
+        """
         return self._queue
 
     def schedule(
-        self, callback: Callable[[PubSubMessage], Any], *args: list[Any], **kwargs: dict[str, Any]
+        self,
+        callback: Callable[[PubSubMessage], Any],
+        *args: list[Any],
+        **kwargs: dict[str, Any],
     ) -> None:
-        """Schedule the callback to be called asynchronously in the event loop thread.
+        """Schedule the callback to be called in the event loop thread async.
 
         Args:
             callback: The function to call.
@@ -77,7 +84,9 @@ class AsyncScheduler(Scheduler):  # type: ignore[misc]
             )
 
     def register_task_execution(
-        self, task: asyncio.Task[Callable[[PubSubMessage], Awaitable[Any]]], message: PubSubMessage
+        self,
+        task: asyncio.Task[Callable[[PubSubMessage], Awaitable[Any]]],
+        message: PubSubMessage,
     ) -> None:
         """Register a task for tracking.
 
@@ -132,25 +141,30 @@ class AsyncScheduler(Scheduler):  # type: ignore[misc]
             pending, executing = self.get_in_flight_count()
 
             if pending == 0 and executing == 0:
-                logger.debug("All asynchronous tasks were completed successfully.")
+                logger.debug(
+                    "All asynchronous tasks were completed successfully."
+                )
                 return True
 
-            logger.debug(
-                f"Waiting for {pending} pending and {executing} executing asynchronous tasks."
-            )
+            logger.debug(f"Waiting for {pending} pending asynchronous tasks.")
             await asyncio.sleep(0.5)
 
-        logger.warning(f"Timeout after {timeout}s waiting for messages completion")
+        logger.warning(
+            f"Timeout after {timeout}s waiting for messages completion"
+        )
         return False
 
-    def shutdown(self, await_msg_callbacks: bool = True) -> list[PubSubMessage]:
+    def shutdown(
+        self, await_msg_callbacks: bool = True
+    ) -> list[PubSubMessage]:
         """Shuts down the scheduler and cancels executing tasks.
 
         Args:
             await_msg_callbacks:
-                If ``True`` (default), the method will cancel the executing callbacks remaining.
-                This will allow a graceful termination of the messages execution.
-                If ``False``, the method will not cancel the callbacks.
+                If ``True`` (default), the method will cancel the executing
+                callbacks remaining. This will allow a graceful
+                termination of the messages execution. If ``False``,
+                the method will not cancel the callbacks.
 
         Returns:
             The messages dispatched to the asyncio loop that are currently
@@ -170,8 +184,10 @@ class AsyncScheduler(Scheduler):  # type: ignore[misc]
                 dropped_messages.append(message)
 
         if dropped_messages:
-            logger.warning(f"Scheduler shutdown: {len(dropped_messages)} messages will be nacked.")
+            logger.warning(
+                f"Scheduler shutdown: {len(dropped_messages)} messages nacked."
+            )
             return dropped_messages
 
-        logger.debug("Scheduler shutdown: All asynchronous tasks completed successfully.")
+        logger.debug("Scheduler shutdown: All asynchronous tasks completed.")
         return dropped_messages

--- a/fastpubsub/concurrency/manager.py
+++ b/fastpubsub/concurrency/manager.py
@@ -53,11 +53,9 @@ class AsyncTaskManager:
     async def shutdown(self, timeout: float = 30.0) -> None:
         """Gracefully shuts down all tasks, waiting for message completion.
 
-        First, we cancel all StreamingPullFutures to stop new messages from arriving.
-        Then, we wait for in-flight messages to complete (or timeout).
-
         Args:
-            timeout: Maximum time to wait for in-flight messages per subscription (seconds).
+            timeout: Maximum time towait for in-flight messages
+                per subscription in seconds.
         """
         logger.info(f"Starting graceful shutdown with {timeout}s timeout...")
 
@@ -68,7 +66,9 @@ class AsyncTaskManager:
                         if task.task_alive():
                             tg.create_task(task.shutdown(timeout=timeout))
         except TimeoutError as e:
-            logger.warning(f"A timeout happened while turning of a subscriber {e}")
+            logger.warning(
+                f"A timeout happened while turning of a subscriber {e}"
+            )
         finally:
             self._tasks.clear()
             await PubSubClientFactory.close_all()

--- a/fastpubsub/concurrency/tasks.py
+++ b/fastpubsub/concurrency/tasks.py
@@ -5,7 +5,10 @@ import logging
 from concurrent.futures import Future
 from typing import Any, cast
 
-from google.cloud.pubsub_v1.subscriber.exceptions import AcknowledgeError, AcknowledgeStatus
+from google.cloud.pubsub_v1.subscriber.exceptions import (
+    AcknowledgeError,
+    AcknowledgeStatus,
+)
 from google.cloud.pubsub_v1.subscriber.futures import StreamingPullFuture
 from google.cloud.pubsub_v1.subscriber.message import Message as PubSubMessage
 
@@ -21,7 +24,7 @@ logger: FastPubSubLogger = cast(FastPubSubLogger, logging.getLogger(__name__))
 
 
 class MessageMapper:
-    """A mapper used to deserialize a Pub/Sub message into a fastpubsub.Message class."""
+    """A object to deserialize a Pub/Sub message into a fastpubsub.Message."""
 
     def __init__(self, subscriber: Subscriber):
         """Initializes the MessageMapper.
@@ -57,7 +60,7 @@ class MessageMapper:
 
 
 class PubSubStreamingPullTask:
-    """A task for polling messages from a Pub/Sub subscription with StreamingPull API."""
+    """A task for polling messages from a Pub/Sub subscription."""
 
     def __init__(self, subscriber: Subscriber) -> None:
         """Initializes the PubSubPollTask.
@@ -75,7 +78,9 @@ class PubSubStreamingPullTask:
 
     async def start(self) -> None:
         """Starts the message polling loop."""
-        logger.info(f"The {self.subscriber.name} handler is waiting for messages.")
+        logger.info(
+            f"The {self.subscriber.name} handler is waiting for messages."
+        )
         self.task = await self.client.subscribe(
             callback=self._on_message,
             subscription_name=self.subscriber.subscription_name,
@@ -117,7 +122,9 @@ class PubSubStreamingPullTask:
             except Exception:
                 future = received_message.nack_with_response()
                 await self._wait_acknowledge_response(future=future)
-                logger.exception("Unhandled exception on message", stacklevel=5)
+                logger.exception(
+                    "Unhandled exception on message", stacklevel=5
+                )
                 return
 
     async def _wait_acknowledge_response(self, future: Future[Any]) -> None:
@@ -126,13 +133,17 @@ class PubSubStreamingPullTask:
         except AcknowledgeError as e:
             self._on_acknowledge_failed(e)
         except TimeoutError:
-            logger.error("The acknowledge response took too long. The message will be retried.")
+            logger.error(
+                "The acknowledge response took too long. "
+                "The message will be retried."
+            )
 
     def _on_acknowledge_failed(self, e: AcknowledgeError) -> None:
         match e.error_code:
             case AcknowledgeStatus.PERMISSION_DENIED:
                 logger.exception(
-                    "The subscriber does not have permission to ack/nack the message or the "
+                    "The subscriber does not have permission "
+                    "to ack/nack the message or the "
                     "subscription does not exists anymore.",
                     stacklevel=5,
                 )
@@ -144,10 +155,15 @@ class PubSubStreamingPullTask:
                 )
             case AcknowledgeStatus.INVALID_ACK_ID:
                 logger.info(
-                    "The message ack_id expired. It will be redelivered later.", exc_info=True
+                    "The message ack_id expired. "
+                    "It will be redelivered later.",
+                    exc_info=True,
                 )
             case _:
-                logger.exception("Some unknown error happened during ack/nack.", stacklevel=5)
+                logger.exception(
+                    "Some unknown error happened during ack/nack.",
+                    stacklevel=5,
+                )
 
     def task_ready(self) -> bool:
         """Checks if the task is ready.

--- a/fastpubsub/concurrency/utils.py
+++ b/fastpubsub/concurrency/utils.py
@@ -20,7 +20,9 @@ T = TypeVar("T")
 
 
 def ensure_async_callable_function(
-    callable_object: Callable[[], Any] | AsyncCallable | AsyncDecoratedCallable,
+    callable_object: Callable[[], Any]
+    | AsyncCallable
+    | AsyncDecoratedCallable,
 ) -> None:
     """Ensures that a callable is an async function.
 
@@ -28,7 +30,9 @@ def ensure_async_callable_function(
         callable_object: The callable to check.
     """
     if not isinstance(callable_object, FunctionType):
-        raise TypeError(f"The object must be a function type but it is {callable_object}.")
+        raise TypeError(
+            f"The object must be a function type but it is {callable_object}."
+        )
 
     if not inspect.iscoroutinefunction(callable_object):
         raise TypeError(f"The function {callable_object} must be async.")
@@ -43,16 +47,24 @@ def ensure_async_middleware(middleware: type["BaseMiddleware"]) -> None:
     from fastpubsub.middlewares.base import BaseMiddleware
 
     if not issubclass(middleware, BaseMiddleware):
-        raise TypeError(f"The object {middleware} must be a {BaseMiddleware.__name__}.")
+        raise TypeError(
+            f"The object {middleware} must be a {BaseMiddleware.__name__}."
+        )
 
     if not inspect.iscoroutinefunction(middleware.on_message):
-        raise TypeError(f"The on_message method must be async on {middleware}.")
+        raise TypeError(
+            f"The on_message method must be async on {middleware}."
+        )
 
     if not inspect.iscoroutinefunction(middleware.on_publish):
-        raise TypeError(f"The on_publish method must be async on {middleware}.")
+        raise TypeError(
+            f"The on_publish method must be async on {middleware}."
+        )
 
 
-async def apply_async(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+async def apply_async(
+    func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
+) -> T:
     """Transforms a blocking sync callable into a async callable.
 
     Args:
@@ -68,8 +80,10 @@ async def apply_async(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -
     return await anyio.to_thread.run_sync(func, abandon_on_cancel=False)
 
 
-async def apply_async_cancellable(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
-    """Transforms a blocking sync callable into a async callable that can be cancelled.
+async def apply_async_cancellable(
+    func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
+) -> T:
+    """Transforms a blocking sync callable into a async cancellable callable.
 
     Args:
         func: The sync callable to be transformed.

--- a/fastpubsub/datastructures.py
+++ b/fastpubsub/datastructures.py
@@ -68,8 +68,12 @@ class PushMessageContent(BaseModel):
 
     id: str = Field(alias="messageId", title="The message id")
     data: str = Field(title="The message content base64-encoded")
-    publish_time: str = Field(alias="publishTime", title="The publish datetime of the message")
-    attributes: dict[str, str] = Field({}, title="The attributes of the message")
+    publish_time: str = Field(
+        alias="publishTime", title="The publish datetime of the message"
+    )
+    attributes: dict[str, str] = Field(
+        {}, title="The attributes of the message"
+    )
 
 
 class PushMessage(BaseModel):

--- a/fastpubsub/logger.py
+++ b/fastpubsub/logger.py
@@ -19,7 +19,9 @@ class ContextStore:
 
     def __init__(self) -> None:
         """Initializes the ContextStore."""
-        self._context: ContextVar[dict[str, str] | None] = ContextVar("context_store", default=None)
+        self._context: ContextVar[dict[str, str] | None] = ContextVar(
+            "context_store", default=None
+        )
 
     def set(self, data: dict[str, Any]) -> Token[dict[str, str] | None]:
         """Sets or updates the context data.
@@ -96,11 +98,21 @@ class DefaultFormatter(logging.Formatter):
     """Default formatter for a human-readable string."""
 
     level_name_colors = {
-        logging.DEBUG: lambda level_name: click.style(str(level_name), fg="cyan"),
-        logging.INFO: lambda level_name: click.style(str(level_name), fg="green"),
-        logging.WARNING: lambda level_name: click.style(str(level_name), fg="yellow"),
-        logging.ERROR: lambda level_name: click.style(str(level_name), fg="red"),
-        logging.CRITICAL: lambda level_name: click.style(str(level_name), fg="bright_red"),
+        logging.DEBUG: lambda level_name: click.style(
+            str(level_name), fg="cyan"
+        ),
+        logging.INFO: lambda level_name: click.style(
+            str(level_name), fg="green"
+        ),
+        logging.WARNING: lambda level_name: click.style(
+            str(level_name), fg="yellow"
+        ),
+        logging.ERROR: lambda level_name: click.style(
+            str(level_name), fg="red"
+        ),
+        logging.CRITICAL: lambda level_name: click.style(
+            str(level_name), fg="bright_red"
+        ),
     }
 
     def __init__(
@@ -130,7 +142,9 @@ class DefaultFormatter(logging.Formatter):
         levelname = recordcopy.levelname
         separator = " " * (8 - len(recordcopy.levelname))
         if self.use_colors:
-            levelname = self._get_colored_levelname(recordcopy.levelno, recordcopy.levelname)
+            levelname = self._get_colored_levelname(
+                recordcopy.levelno, recordcopy.levelname
+            )
             if "color_message" in recordcopy.__dict__:
                 recordcopy.msg = recordcopy.__dict__["color_message"]
                 recordcopy.__dict__["message"] = recordcopy.getMessage()
@@ -185,7 +199,9 @@ def configure() -> FastPubSubLogger:
     """Enables and configures the FastPubSub logger."""
     LOGGING_LEVEL = os.getenv("FASTPUBSUB_LOG_LEVEL", "INFO")
     LOGGING_COLORIZE = bool(int(os.getenv("FASTPUBSUB_ENABLE_LOG_COLORS", 0)))
-    LOGGING_SERIALIZE = bool(int(os.getenv("FASTPUBSUB_ENABLE_LOG_SERIALIZE", 0)))
+    LOGGING_SERIALIZE = bool(
+        int(os.getenv("FASTPUBSUB_ENABLE_LOG_SERIALIZE", 0))
+    )
 
     LOGGING_CONFIG: dict[str, Any] = {
         "version": 1,
@@ -209,7 +225,9 @@ def configure() -> FastPubSubLogger:
         },
         "handlers": {
             "fastpubsub_default": {
-                "formatter": "fastpubsub_json" if LOGGING_SERIALIZE else "fastpubsub_default",
+                "formatter": "fastpubsub_json"
+                if LOGGING_SERIALIZE
+                else "fastpubsub_default",
                 "class": "logging.StreamHandler",
                 "stream": "ext://sys.stderr",
                 "filters": ["fastpubsub_filter"],

--- a/fastpubsub/middlewares/base.py
+++ b/fastpubsub/middlewares/base.py
@@ -59,10 +59,13 @@ class Middleware:
     """Wrapper class for middlewares.
 
     You should only use this class to create middlewares on class constructors.
-    Its purpose is to only store the middleware information for delayed initiatization.
+    Its purpose is to only store the middleware. information for delayed
+    initiatization.
     """
 
-    def __init__(self, cls: type[BaseMiddleware], *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, cls: type[BaseMiddleware], *args: Any, **kwargs: Any
+    ) -> None:
         """Initializes the Middleware.
 
         Args:
@@ -91,7 +94,9 @@ class Middleware:
         """
         class_name = self.__class__.__name__
         args_strings = [f"{value!r}" for value in self.args]
-        option_strings = [f"{key}={value!r}" for key, value in self.kwargs.items()]
+        option_strings = [
+            f"{key}={value!r}" for key, value in self.kwargs.items()
+        ]
         name = getattr(self.cls, "__name__", "")
         args_repr = ", ".join([name] + args_strings + option_strings)
         return f"{class_name}({args_repr})"

--- a/fastpubsub/middlewares/di.py
+++ b/fastpubsub/middlewares/di.py
@@ -11,7 +11,9 @@ from fastpubsub.types import AsyncCallable
 class HandleMessageSerializerMiddleware(BaseMiddleware):
     """A special middleware for handling incoming messages serialization."""
 
-    def __init__(self, next_call: BaseMiddleware | None, target: AsyncCallable):
+    def __init__(
+        self, next_call: BaseMiddleware | None, target: AsyncCallable
+    ):
         """Initializes the HandleMessageSerializerMiddleware.
 
         Args:
@@ -71,5 +73,8 @@ class PublishMessageSerializerMiddleware(BaseMiddleware):
             await client.create_topic(self.topic_name)
 
         return await client.publish(
-            topic_name=self.topic_name, data=data, ordering_key=ordering_key, attributes=attributes
+            topic_name=self.topic_name,
+            data=data,
+            ordering_key=ordering_key,
+            attributes=attributes,
         )

--- a/fastpubsub/middlewares/gzip.py
+++ b/fastpubsub/middlewares/gzip.py
@@ -11,7 +11,10 @@ class GZipMiddleware(BaseMiddleware):
     """A middleware for compressing and decompressing messages using gzip."""
 
     def __init__(
-        self, next_call: BaseMiddleware, compresslevel: int = 9, mtime: int | float | None = None
+        self,
+        next_call: BaseMiddleware,
+        compresslevel: int = 9,
+        mtime: int | float | None = None,
     ):
         """Initializes the GZipMiddleware.
 
@@ -65,4 +68,6 @@ class GZipMiddleware(BaseMiddleware):
         compressed_data = gzip.compress(
             data=data, compresslevel=self.compresslevel, mtime=self.mtime
         )
-        return await super().on_publish(compressed_data, ordering_key, attributes)
+        return await super().on_publish(
+            compressed_data, ordering_key, attributes
+        )

--- a/fastpubsub/pubsub/publisher.py
+++ b/fastpubsub/pubsub/publisher.py
@@ -8,7 +8,10 @@ from pydantic import BaseModel, ConfigDict, validate_call
 
 from fastpubsub.concurrency.utils import ensure_async_middleware
 from fastpubsub.exceptions import FastPubSubException
-from fastpubsub.middlewares import Middleware, PublishMessageSerializerMiddleware
+from fastpubsub.middlewares import (
+    Middleware,
+    PublishMessageSerializerMiddleware,
+)
 from fastpubsub.middlewares.base import BaseMiddleware
 
 
@@ -57,12 +60,17 @@ class Publisher:
         serialized_message = await self._serialize_message(data)
 
         await callstack.on_publish(
-            data=serialized_message, ordering_key=ordering_key, attributes=attributes
+            data=serialized_message,
+            ordering_key=ordering_key,
+            attributes=attributes,
         )
 
     def _build_callstack(self, autocreate: bool = True) -> BaseMiddleware:
         callstack: BaseMiddleware = PublishMessageSerializerMiddleware(
-            None, project_id=self.project_id, topic_name=self.topic_name, autocreate=autocreate
+            None,
+            project_id=self.project_id,
+            topic_name=self.topic_name,
+            autocreate=autocreate,
         )
 
         for middleware, args, kwargs in reversed(self.middlewares):
@@ -70,7 +78,9 @@ class Publisher:
         return callstack
 
     @staticmethod
-    async def _serialize_message(data: BaseModel | dict[str, Any] | str | bytes) -> bytes:
+    async def _serialize_message(
+        data: BaseModel | dict[str, Any] | str | bytes,
+    ) -> bytes:
         if isinstance(data, bytes):
             return data
 
@@ -87,7 +97,8 @@ class Publisher:
 
         raise FastPubSubException(
             f"The message {data} is not serializable. "
-            "Please send as one of the following formats: BaseModel, dict, str or bytes."
+            "Please send as one of the following formats: "
+            "BaseModel, dict, str or bytes."
         )
 
     @validate_call(config=ConfigDict(strict=True))
@@ -98,8 +109,8 @@ class Publisher:
 
         Args:
             middleware: The middleware to include.
-            args: The positional arguments used on the middleware instantiation.
-            kwargs: The keyword  arguments used on the middleware instantiation.
+            args: The positional arguments used on middleware instantiation.
+            kwargs: The keyword  arguments used on middleware instantiation.
         """
         ensure_async_middleware(middleware)
 

--- a/fastpubsub/pubsub/subscriber.py
+++ b/fastpubsub/pubsub/subscriber.py
@@ -13,7 +13,10 @@ from fastpubsub.datastructures import (
     MessageDeliveryPolicy,
     MessageRetryPolicy,
 )
-from fastpubsub.middlewares import HandleMessageSerializerMiddleware, Middleware
+from fastpubsub.middlewares import (
+    HandleMessageSerializerMiddleware,
+    Middleware,
+)
 from fastpubsub.middlewares.base import BaseMiddleware
 from fastpubsub.types import AsyncCallable
 
@@ -73,8 +76,8 @@ class Subscriber:
 
         Args:
             middleware: The middleware to include.
-            args: The positional arguments used on the middleware instantiation.
-            kwargs: The keyword  arguments used on the middleware instantiation.
+            args: The positional arguments used on middleware instantiation.
+            kwargs: The keyword arguments used on middleware instantiation.
         """
         ensure_async_middleware(middleware)
 
@@ -85,7 +88,9 @@ class Subscriber:
         self.middlewares.append(wrapper_middleware)
 
     def _build_callstack(self) -> BaseMiddleware:
-        callstack: BaseMiddleware = HandleMessageSerializerMiddleware(None, self.func)
+        callstack: BaseMiddleware = HandleMessageSerializerMiddleware(
+            None, self.func
+        )
         for middleware, args, kwargs in reversed(self.middlewares):
             callstack = middleware(callstack, *args, **kwargs)
         return callstack

--- a/fastpubsub/router.py
+++ b/fastpubsub/router.py
@@ -40,20 +40,23 @@ class PubSubRouter:
 
         Args:
             prefix: A prefix to apply to all subscribers and publishers in the
-                router. If set, the subscriber alias will be: <prefix>.<alias>.
+                router. If set, the subscriber alias will be: {prefix}.{alias}.
                 Also, it affects the subscription name. A subscription will be
-                <prefix>.<subscription_name>.
-            project_id: An alternative project id to the broker's project id.
+                {prefix}.{subscription_name}.
+            project_id: An alternative project id to the router's project id.
                 All the publishers and subscriber created with this router
-                will use this attribute instead of the project id set at broker-level.
+                will use this attribute instead of the project id set at
+                router-level.
             routers: A sequence of children routers to include.
             middlewares: A sequence of middlewares to apply to all subscribers
                 in this router and its children.
         """
         if prefix and not _PREFIX_REGEX.match(prefix):
             raise FastPubSubException(
-                "Prefix must be a string that starts and ends with a letter or number, "
-                "and can only contain periods, slashes, or underscores in the middle."
+                "Prefix must be a string that starts and "
+                "ends with a letter or number, "
+                "and can only contain periods, "
+                "slashes, or underscores in the middle."
             )
 
         self.prefix = prefix
@@ -65,14 +68,18 @@ class PubSubRouter:
 
         if routers:
             if not isinstance(routers, Sequence):
-                raise FastPubSubException("Your routers should be passed as a sequence")
+                raise FastPubSubException(
+                    "Your routers should be passed as a sequence"
+                )
 
             for router in routers:
                 self.include_router(router)
 
         if middlewares:
             if not isinstance(middlewares, Sequence):
-                raise FastPubSubException("Your routers should be passed as a sequence")
+                raise FastPubSubException(
+                    "Your routers should be passed as a sequence"
+                )
 
             for middleware, args, kwargs in middlewares:
                 self.include_middleware(middleware, *args, **kwargs)
@@ -102,13 +109,17 @@ class PubSubRouter:
             router: The router to include.
         """
         if not (router and isinstance(router, PubSubRouter)):
-            raise FastPubSubException(f"Your routers must be of type {self.__class__.__name__}")
+            raise FastPubSubException(
+                f"Your routers must be of type {self.__class__.__name__}"
+            )
 
         if self == router:
             # V2: Create a algorithm to detect cycles on these routers.
             # For now, let us assume that the router is well configured
             # and this is the only error case.
-            raise FastPubSubException(f"There is a cyclical reference on router {self.prefix}.")
+            raise FastPubSubException(
+                f"There is a cyclical reference on router {self.prefix}."
+            )
 
         router._add_prefix(self.prefix)
         router._set_project_id(self.project_id)
@@ -118,7 +129,9 @@ class PubSubRouter:
 
         self.routers.append(router)
 
-    @validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
+    @validate_call(
+        config=ConfigDict(strict=True, arbitrary_types_allowed=True)
+    )
     def subscriber(
         self,
         alias: str,
@@ -145,25 +158,29 @@ class PubSubRouter:
             alias: A unique name for the subscriber. You can use this alias to
                 select which subscription to use on the CLI.
             topic_name: The name of the topic to subscribe to.
-            subscription_name: The name of the subscription attached to the topic.
+            subscription_name: The name of the subscription for the topic.
             project_id: An alternative project id to create a subscription
                 and consume messages from. If set the router project id
                 will be ignored.
-            autocreate: Whether to automatically create the topic and
+            autocreate: Automatically creates the topic and
                 subscription if they do not exists.
-            autoupdate: Whether to automatically update the subscription.
+            autoupdate: Automatically updates the subscription.
             filter_expression: A filter expression to apply to the
                 subscription to filter messages.
             dead_letter_topic: The name of the dead-letter topic.
             max_delivery_attempts: The maximum number of delivery attempts
                 before sending the message to the dead-letter.
             ack_deadline_seconds: The acknowledgment deadline in seconds.
-            enable_message_ordering: Whether the message must be delivered in order.
-            enable_exactly_once_delivery: Whether to enable exactly-once delivery.
+            enable_message_ordering: Enables message ordering.
+                It can only be set when creating the subscription.
+            enable_exactly_once_delivery: Enables exactly-once delivery.
+                It can only be set when creating the subscription.
             min_backoff_delay_secs: The minimum backoff delay in seconds.
             max_backoff_delay_secs: The maximum backoff delay in seconds.
-            max_messages: The maximum number of messages to fetch from the broker.
-            middlewares: A sequence of middlewares to apply **only to the subscriber**.
+            max_messages: The maximum number of messages to fetch from
+                the broker at a time.
+            middlewares: A sequence of middlewares to apply to the subscriber.
+                It is subscriber specific, not application-wide.
 
         Returns:
             A decorator that registers the function as a subscriber.
@@ -177,7 +194,9 @@ class PubSubRouter:
 
             if self.prefix and isinstance(self.prefix, str):
                 prefixed_alias = f"{self.prefix}.{prefixed_alias}"
-                prefixed_subscription_name = f"{self.prefix}.{prefixed_subscription_name}"
+                prefixed_subscription_name = (
+                    f"{self.prefix}.{prefixed_subscription_name}"
+                )
 
             if prefixed_alias in self.subscribers:
                 raise FastPubSubException(
@@ -188,7 +207,8 @@ class PubSubRouter:
             dead_letter_policy = None
             if dead_letter_topic:
                 dead_letter_policy = DeadLetterPolicy(
-                    topic_name=dead_letter_topic, max_delivery_attempts=max_delivery_attempts
+                    topic_name=dead_letter_topic,
+                    max_delivery_attempts=max_delivery_attempts,
                 )
 
             retry_policy = MessageRetryPolicy(
@@ -203,7 +223,9 @@ class PubSubRouter:
                 enable_exactly_once_delivery=enable_exactly_once_delivery,
             )
 
-            lifecycle_policy = LifecyclePolicy(autocreate=autocreate, autoupdate=autoupdate)
+            lifecycle_policy = LifecyclePolicy(
+                autocreate=autocreate, autoupdate=autoupdate
+            )
 
             control_flow_policy = MessageControlFlowPolicy(
                 max_messages=max_messages,
@@ -245,7 +267,9 @@ class PubSubRouter:
         """
         chosen_project_id = project_id or self.project_id
         publisher = Publisher(
-            topic_name=topic_name, project_id=chosen_project_id, middlewares=self.middlewares
+            topic_name=topic_name,
+            project_id=chosen_project_id,
+            middlewares=self.middlewares,
         )
         self.publishers.add(publisher)
         return publisher
@@ -269,11 +293,16 @@ class PubSubRouter:
                         If set the router project id will be ignored.
             ordering_key: The ordering key for the message.
             attributes: A dictionary of message attributes.
-            autocreate: Whether to automatically create the topic if it does not exists.
+            autocreate: Automatically creates the topic if it does not exists.
         """
-        publisher = self.publisher(topic_name=topic_name, project_id=project_id)
+        publisher = self.publisher(
+            topic_name=topic_name, project_id=project_id
+        )
         await publisher.publish(
-            data=data, ordering_key=ordering_key, attributes=attributes, autocreate=autocreate
+            data=data,
+            ordering_key=ordering_key,
+            attributes=attributes,
+            autocreate=autocreate,
         )
 
     @validate_call(config=ConfigDict(strict=True))
@@ -284,8 +313,8 @@ class PubSubRouter:
 
         Args:
             middleware: The middleware to include.
-            args: The positional arguments used on the middleware instantiation.
-            kwargs: The keyword  arguments used on the middleware instantiation.
+            args: The positional arguments used on middleware instantiation.
+            kwargs: The keyword  arguments used on middleware instantiation.
         """
         for publisher in self.publishers:
             publisher.include_middleware(middleware, *args, **kwargs)
@@ -310,9 +339,11 @@ class PubSubRouter:
                 if alias in subscribers:
                     existing_subscriber = subscribers[alias]
                     raise FastPubSubException(
-                        f"Conflict on subscribers {new_subscriber} and {existing_subscriber}. "
-                        f"The conflict occurs on alias={alias} and router prefix={self.prefix}. "
-                        f"Maybe you should use a different alias or prefix?"
+                        f"Conflict on subscribers {new_subscriber} "
+                        f"and {existing_subscriber}. The conflict "
+                        f"occurs on alias={alias} and router "
+                        f"prefix={self.prefix}. Maybe you "
+                        "should use a different alias or prefix?"
                     )
 
             subscribers.update(router_subscribers)

--- a/fastpubsub/testing.py
+++ b/fastpubsub/testing.py
@@ -13,7 +13,12 @@ from fastpubsub.pubsub import Publisher
 if TYPE_CHECKING:
     from fastpubsub.broker import PubSubBroker
 
-__all__ = ["PubSubTestClient", "PublishedMessage", "ProcessingResult", "matches_filter"]
+__all__ = [
+    "PubSubTestClient",
+    "PublishedMessage",
+    "ProcessingResult",
+    "matches_filter",
+]
 
 
 @dataclass(frozen=True)
@@ -97,17 +102,23 @@ def _tokenize(expression: str) -> list[_Token]:
         remaining = expression[pos:]
 
         # Logical operators (must check before identifiers)
-        if remaining.startswith("AND") and (len(remaining) == 3 or not remaining[3].isalnum()):
+        if remaining.startswith("AND") and (
+            len(remaining) == 3 or not remaining[3].isalnum()
+        ):
             tokens.append(_Token(_TokenType.AND, "AND"))
             pos += 3
             continue
 
-        if remaining.startswith("OR") and (len(remaining) == 2 or not remaining[2].isalnum()):
+        if remaining.startswith("OR") and (
+            len(remaining) == 2 or not remaining[2].isalnum()
+        ):
             tokens.append(_Token(_TokenType.OR, "OR"))
             pos += 2
             continue
 
-        if remaining.startswith("NOT") and (len(remaining) == 3 or not remaining[3].isalnum()):
+        if remaining.startswith("NOT") and (
+            len(remaining) == 3 or not remaining[3].isalnum()
+        ):
             tokens.append(_Token(_TokenType.NOT, "NOT"))
             pos += 3
             continue
@@ -174,7 +185,8 @@ def _tokenize(expression: str) -> list[_Token]:
         if expression[pos].isalpha() or expression[pos] == "_":
             end_pos = pos
             while end_pos < length and (
-                expression[end_pos].isalnum() or expression[end_pos] in ("_", "-")
+                expression[end_pos].isalnum()
+                or expression[end_pos] in ("_", "-")
             ):
                 end_pos += 1
             identifier = expression[pos:end_pos]
@@ -182,7 +194,9 @@ def _tokenize(expression: str) -> list[_Token]:
             pos = end_pos
             continue
 
-        raise ValueError(f"Unexpected character '{expression[pos]}' at position {pos}")
+        raise ValueError(
+            f"Unexpected character '{expression[pos]}' at position {pos}"
+        )
 
     tokens.append(_Token(_TokenType.EOF, ""))
     return tokens
@@ -200,7 +214,9 @@ class _FilterParser:
     - Parentheses for grouping
     """
 
-    def __init__(self, tokens: list[_Token], attributes: dict[str, str]) -> None:
+    def __init__(
+        self, tokens: list[_Token], attributes: dict[str, str]
+    ) -> None:
         """Initialize the parser.
 
         Args:
@@ -246,7 +262,9 @@ class _FilterParser:
     def _expect(self, token_type: _TokenType) -> _Token:
         """Expect a specific token type, raise error if not found."""
         if self._current().type != token_type:
-            raise ValueError(f"Expected {token_type.name}, got {self._current().type.name}")
+            raise ValueError(
+                f"Expected {token_type.name}, got {self._current().type.name}"
+            )
         return self._advance()
 
     def _or_expr(self) -> bool:
@@ -272,7 +290,7 @@ class _FilterParser:
         return self._primary()
 
     def _primary(self) -> bool:
-        """Parse primary expressions (comparisons, existence, hasPrefix, parens)."""
+        """Parse primary expressions."""
         # Parenthesized expression
         if self._match(_TokenType.LPAREN):
             result = self._or_expr()
@@ -368,9 +386,9 @@ def matches_filter(attributes: dict[str, str], filter_expression: str) -> bool:
 class PubSubTestClient:
     """A test wrapper for PubSubBroker that enables in-memory message routing.
 
-    This allows testing subscriber handlers without needing a real PubSub emulator,
-    making tests fast and isolated. Supports filter expression evaluation to match
-    Google Pub/Sub behavior.
+    This allows testing subscriber handlers without needing a real PubSub
+    emulator,making tests fast and isolated. Supports filter expression
+    evaluation to match Google Pub/Sub behavior.
 
     Example:
         ```python
@@ -462,7 +480,9 @@ class PubSubTestClient:
         mock_builder_class.return_value = mock_builder
 
         # Mock the task manager to not actually start async tasks
-        task_manager_patcher = patch.object(self.broker.task_manager, "start", AsyncMock())
+        task_manager_patcher = patch.object(
+            self.broker.task_manager, "start", AsyncMock()
+        )
         task_manager_patcher.start()
         self._patchers.append(task_manager_patcher)
 
@@ -489,8 +509,8 @@ class PubSubTestClient:
         """Fake publish that routes messages to matching subscribers.
 
         Routes messages based on topic name, project_id, AND filter expression
-        matching. If a subscriber has a filter expression, only messages matching
-        that filter will be delivered to the subscriber.
+        matching. If a subscriber has a filter expression, only messages
+        matching that filter will be delivered to the subscriber.
 
         Args:
             topic_name: Target topic.
@@ -518,7 +538,9 @@ class PubSubTestClient:
             if subscriber.topic_name != topic_name:
                 continue
 
-            subscriber_project_id = subscriber.project_id or self.broker.project_id
+            subscriber_project_id = (
+                subscriber.project_id or self.broker.project_id
+            )
             if subscriber_project_id != resolved_project_id:
                 continue
 
@@ -575,7 +597,11 @@ class PubSubTestClient:
         resolved_project_id = project_id or self.broker.project_id
         encoded_data = await Publisher._serialize_message(data)
         await self._fake_publish(
-            topic, encoded_data, ordering_key, attributes, project_id=resolved_project_id
+            topic,
+            encoded_data,
+            ordering_key,
+            attributes,
+            project_id=resolved_project_id,
         )
 
     def get_published_messages(self) -> list[PublishedMessage]:
@@ -601,8 +627,14 @@ class PubSubTestClient:
 
 
             async with PubSubTestClient(broker) as client:
-                await client.publish({"id": 1}, topic="order-events", attributes={"region": "us"})
-                await client.publish({"id": 2}, topic="order-events", project_id="other-project")
+                await client.publish(
+                    {"id": 1},
+                    topic="order-events",
+                    attributes={"region": "us"},
+                )
+                await client.publish(
+                    {"id": 2}, topic="order-events", project_id="other-project"
+                )
 
                 messages = client.get_published_messages()
                 assert len(messages) == 2

--- a/fastpubsub/types.py
+++ b/fastpubsub/types.py
@@ -1,13 +1,8 @@
 """Type definitions for FastPubSub."""
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    pass
-
-
-# V2: We wait a return because in further releases we will allow chaining handlers/publishers
 AsyncDecoratedCallable = Callable[[Any], Awaitable[Any]]
 SubscribedCallable = Callable[[AsyncDecoratedCallable], AsyncDecoratedCallable]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ disallow_untyped_decorators = true
 disallow_any_unimported = false
 
 [tool.ruff]
-line-length = 100
+line-length = 79
 exclude = ["**/__about__.py"]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "fastpubsub"
 description = "FastPubSub: A high-performance, asyncio-native framework for Google Cloud Pub/Sub applications"
 readme = "README.md"
-version = "0.9.2"
+version = "0.9.3"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,9 @@ def router_factory() -> Callable[..., PubSubRouter]:
     return _create
 
 
-def callstack_to_collection(callstack: BaseMiddleware) -> MutableSequence[BaseMiddleware]:
+def callstack_to_collection(
+    callstack: BaseMiddleware,
+) -> MutableSequence[BaseMiddleware]:
     """Receives a callstack and transform it into an ordered sequence.
 
     Args:
@@ -96,13 +98,16 @@ def callstack_matches(
         True if the callstack matches the expected output, False otherwise.
     """
     callstack_collection = callstack_to_collection(callstack)
-    assert len(callstack_collection) == len(expected_output), "The callstacks do not match in size"
+    assert len(callstack_collection) == len(expected_output), (
+        "The callstacks do not match in size"
+    )
 
     for i in range(len(callstack_collection)):
         existing_middleware = type(callstack_collection[i])
         expected_middlewares = expected_output[i]
         assert existing_middleware == expected_middlewares, (
-            f"The callstack on {i} is {existing_middleware} but should be {expected_middlewares}"
+            f"The callstack on {i} is {existing_middleware} "
+            f"but should be {expected_middlewares}"
         )
 
     return True

--- a/tests/docs/advanced/test_custom_middlewares.py
+++ b/tests/docs/advanced/test_custom_middlewares.py
@@ -33,7 +33,11 @@ class TestAdvancedCustomMiddlewares:
             middlewares=[Middleware(ValidationMiddleware)],
         )
 
-        @broker.subscriber(alias="validator", topic_name="events", subscription_name="events-sub")
+        @broker.subscriber(
+            alias="validator",
+            topic_name="events",
+            subscription_name="events-sub",
+        )
         async def _handler(message: Message) -> str:
             return message.data.decode("utf-8")
 
@@ -48,12 +52,16 @@ class TestAdvancedCustomMiddlewares:
 
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_publisher_metadata_middleware_enriches_attributes(self) -> None:
+    async def test_publisher_metadata_middleware_enriches_attributes(
+        self,
+    ) -> None:
         capture = _CapturePublishMiddleware()
         middleware = PublisherMetadataMiddleware(next_call=capture)
 
         await middleware.on_publish(
-            data=b"payload", ordering_key="order-1", attributes={"tenant": "acme"}
+            data=b"payload",
+            ordering_key="order-1",
+            attributes={"tenant": "acme"},
         )
 
         assert len(capture.calls) == 1
@@ -67,11 +75,15 @@ class TestAdvancedCustomMiddlewares:
 
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_publisher_metadata_middleware_handles_missing_attributes(self) -> None:
+    async def test_publisher_metadata_middleware_handles_missing_attributes(
+        self,
+    ) -> None:
         capture = _CapturePublishMiddleware()
         middleware = PublisherMetadataMiddleware(next_call=capture)
 
-        await middleware.on_publish(data=b"payload", ordering_key="", attributes=None)
+        await middleware.on_publish(
+            data=b"payload", ordering_key="", attributes=None
+        )
 
         assert capture.calls[0][2] == {
             "schema-version": "v1",

--- a/tests/docs/advanced/test_delivery_guarantees.py
+++ b/tests/docs/advanced/test_delivery_guarantees.py
@@ -26,12 +26,22 @@ class TestAdvancedDeliveryGuarantees:
 
         monkeypatch.setattr(f"{_SNIPPET}.process_event", process_event)
         monkeypatch.setattr(f"{_SNIPPET}.mark_as_processed", mark_as_processed)
-        monkeypatch.setattr(f"{_SNIPPET}.is_already_processed", _is_already_processed)
+        monkeypatch.setattr(
+            f"{_SNIPPET}.is_already_processed", _is_already_processed
+        )
         mark_as_processed.side_effect = _mark_as_processed
 
         async with PubSubTestClient(broker) as client:
-            await client.publish(topic="events", data={"event": 1}, attributes={"event_id": "e-1"})
-            await client.publish(topic="events", data={"event": 1}, attributes={"event_id": "e-1"})
+            await client.publish(
+                topic="events",
+                data={"event": 1},
+                attributes={"event_id": "e-1"},
+            )
+            await client.publish(
+                topic="events",
+                data={"event": 1},
+                attributes={"event_id": "e-1"},
+            )
             results = client.get_results()
 
         assert len(results) == 2

--- a/tests/docs/advanced/test_filters.py
+++ b/tests/docs/advanced/test_filters.py
@@ -18,15 +18,23 @@ class TestAdvancedFilters:
         process_user_event = AsyncMock()
         log_to_audit_trail = AsyncMock()
         monkeypatch.setattr(f"{_SNIPPET}.process_order", process_order)
-        monkeypatch.setattr(f"{_SNIPPET}.process_user_event", process_user_event)
-        monkeypatch.setattr(f"{_SNIPPET}.log_to_audit_trail", log_to_audit_trail)
+        monkeypatch.setattr(
+            f"{_SNIPPET}.process_user_event", process_user_event
+        )
+        monkeypatch.setattr(
+            f"{_SNIPPET}.log_to_audit_trail", log_to_audit_trail
+        )
 
         async with PubSubTestClient(broker) as client:
             await client.publish(
-                topic="multi-events", data="order", attributes={"event_type": "order"}
+                topic="multi-events",
+                data="order",
+                attributes={"event_type": "order"},
             )
             await client.publish(
-                topic="multi-events", data="user", attributes={"event_type": "user"}
+                topic="multi-events",
+                data="user",
+                attributes={"event_type": "user"},
             )
             results = client.get_results()
 
@@ -40,7 +48,9 @@ class TestAdvancedFilters:
 
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_filtered_subscriber_does_not_receive_message_without_attributes(self) -> None:
+    async def test_subscriber_does_not_receive_unfiltered_message(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await client.publish(topic="events", data="ignored")
             results = client.get_results()

--- a/tests/docs/advanced/test_multiple_projects.py
+++ b/tests/docs/advanced/test_multiple_projects.py
@@ -10,7 +10,9 @@ class TestAdvancedMultipleProjects:
     async def test_cross_project_publish_targets_project_b(self) -> None:
         async with PubSubTestClient(broker) as client:
             await client.publish(
-                topic="shared-events", data={"id": "evt-1"}, project_id="project-b"
+                topic="shared-events",
+                data={"id": "evt-1"},
+                project_id="project-b",
             )
             published_messages = client.get_published_messages()
 

--- a/tests/docs/advanced/test_ordering.py
+++ b/tests/docs/advanced/test_ordering.py
@@ -11,7 +11,9 @@ _SNIPPET = "docs.snippets.advanced.e1_04_ordering"
 class TestAdvancedOrdering:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_ordered_publish_sets_ordering_key_and_attributes(self) -> None:
+    async def test_ordered_publish_sets_ordering_key_and_attributes(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await user_action()
             published_messages = client.get_published_messages()

--- a/tests/docs/advanced/test_tuning.py
+++ b/tests/docs/advanced/test_tuning.py
@@ -15,7 +15,9 @@ class TestAdvancedTuning:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         fast_async_operation = AsyncMock()
-        monkeypatch.setattr(f"{_SNIPPET}.fast_async_operation", fast_async_operation)
+        monkeypatch.setattr(
+            f"{_SNIPPET}.fast_async_operation", fast_async_operation
+        )
 
         async with PubSubTestClient(broker) as client:
             await client.publish(topic="high-events", data={"value": 1})

--- a/tests/docs/basic_usage/test_cli_example.py
+++ b/tests/docs/basic_usage/test_cli_example.py
@@ -7,7 +7,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestCliExampleSnippet:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_registered_subscribers_process_order_and_notification_topics(self) -> None:
+    async def test_subscriber_listen_order_and_notification_topics(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await client.publish(topic="orders", data={"id": "ord-1"})
             await client.publish(topic="notifications", data={"id": "notif-1"})
@@ -15,7 +17,10 @@ class TestCliExampleSnippet:
             results = client.get_results()
 
         assert len(published_messages) == 2
-        assert [message.topic_name for message in published_messages] == ["orders", "notifications"]
+        assert [message.topic_name for message in published_messages] == [
+            "orders",
+            "notifications",
+        ]
         assert len(results) == 2
         assert [result.message.subscriber_name for result in results] == [
             "handle_orders",

--- a/tests/docs/basic_usage/test_cross_project_publish.py
+++ b/tests/docs/basic_usage/test_cross_project_publish.py
@@ -12,7 +12,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestCrossProjectPublish:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_cross_project_publish_targets_configured_project(self) -> None:
+    async def test_cross_project_publish_targets_configured_project(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_cross_project_broker()
             await publish_cross_project_publisher()
@@ -20,12 +22,19 @@ class TestCrossProjectPublish:
             results = client.get_results()
 
         assert len(published_messages) == 2
-        assert all(message.topic_name == "shared-events" for message in published_messages)
         assert all(
-            message.project_id == "fastpubsub-pubsub-local" for message in published_messages
+            message.topic_name == "shared-events"
+            for message in published_messages
+        )
+        assert all(
+            message.project_id == "fastpubsub-pubsub-local"
+            for message in published_messages
         )
         assert results == []
 
         subscribers = broker.router._get_subscribers()
-        assert subscribers["shared-events-handler"].project_id == "other-project-id"
+        assert (
+            subscribers["shared-events-handler"].project_id
+            == "other-project-id"
+        )
         assert cross_project_publisher.project_id == "other-project-id"

--- a/tests/docs/basic_usage/test_custom_lifespan.py
+++ b/tests/docs/basic_usage/test_custom_lifespan.py
@@ -1,13 +1,18 @@
 import httpx
 import pytest
 
-from docs.snippets.basic_usage.e6_02_custom_lifespan import app, global_lifespan
+from docs.snippets.basic_usage.e6_02_custom_lifespan import (
+    app,
+    global_lifespan,
+)
 
 
 class TestCustomLifespan:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_global_lifespan_creates_and_closes_http_client(self) -> None:
+    async def test_global_lifespan_creates_and_closes_http_client(
+        self,
+    ) -> None:
         client_ref: httpx.AsyncClient | None = None
 
         async with global_lifespan(app):

--- a/tests/docs/basic_usage/test_lifecycle_retry.py
+++ b/tests/docs/basic_usage/test_lifecycle_retry.py
@@ -57,7 +57,9 @@ class TestLifecycleRetry:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         post_mock = AsyncMock()
-        monkeypatch.setattr(f"{_SNIPPET}.httpx.AsyncClient", lambda: _SuccessClient(post_mock))
+        monkeypatch.setattr(
+            f"{_SNIPPET}.httpx.AsyncClient", lambda: _SuccessClient(post_mock)
+        )
 
         async with PubSubTestClient(broker) as client:
             await client.publish(topic="orders", data={"order_id": "ord-200"})
@@ -65,4 +67,6 @@ class TestLifecycleRetry:
 
         assert len(results) == 1
         assert results[0].error is None
-        post_mock.assert_awaited_once_with("https://downstream.service/process/ord-200")
+        post_mock.assert_awaited_once_with(
+            "https://downstream.service/process/ord-200"
+        )

--- a/tests/docs/basic_usage/test_lifespan_hooks.py
+++ b/tests/docs/basic_usage/test_lifespan_hooks.py
@@ -1,13 +1,18 @@
 import pytest
 
-from docs.snippets.basic_usage.e6_01_lifespan_hooks import announce_startup, broker
+from docs.snippets.basic_usage.e6_01_lifespan_hooks import (
+    announce_startup,
+    broker,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestLifespanHooks:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_after_startup_hook_publishes_system_online_message(self) -> None:
+    async def test_after_startup_hook_publishes_system_online_message(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await announce_startup()
             published_messages = client.get_published_messages()

--- a/tests/docs/basic_usage/test_linked_pubsub.py
+++ b/tests/docs/basic_usage/test_linked_pubsub.py
@@ -7,7 +7,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestLinkedPubsub:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_message_from_first_topic_is_chained_to_second_topic(self) -> None:
+    async def test_message_from_first_topic_is_chained_to_second_topic(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await test_publish()
             published_messages = client.get_published_messages()

--- a/tests/docs/basic_usage/test_message_formats.py
+++ b/tests/docs/basic_usage/test_message_formats.py
@@ -1,13 +1,18 @@
 import pytest
 
-from docs.snippets.basic_usage.e2_03_message_formats import broker, publish_initial_messages
+from docs.snippets.basic_usage.e2_03_message_formats import (
+    broker,
+    publish_initial_messages,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestMessageFormats:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_publish_supports_pydantic_dict_string_and_bytes(self) -> None:
+    async def test_publish_supports_pydantic_dict_string_and_bytes(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_initial_messages()
             published_messages = client.get_published_messages()
@@ -22,5 +27,8 @@ class TestMessageFormats:
         assert published_messages[2].data == b"some_string_text"
         assert published_messages[3].data == b"some_byte_text"
 
-        assert all(message.topic_name == "test-topic-pydantic" for message in published_messages)
+        assert all(
+            message.topic_name == "test-topic-pydantic"
+            for message in published_messages
+        )
         assert all(result.error is None for result in processed_messages)

--- a/tests/docs/basic_usage/test_publish_with_attributes.py
+++ b/tests/docs/basic_usage/test_publish_with_attributes.py
@@ -19,9 +19,12 @@ class TestPublishWithAttributes:
             results = client.get_results()
 
         assert len(published_messages) == 2
-        assert all(message.topic_name == "events" for message in published_messages)
         assert all(
-            message.attributes == {"event_type": "user_login", "priority": "high"}
+            message.topic_name == "events" for message in published_messages
+        )
+        assert all(
+            message.attributes
+            == {"event_type": "user_login", "priority": "high"}
             for message in published_messages
         )
         assert all(result.error is None for result in results)

--- a/tests/docs/basic_usage/test_publish_with_ordering.py
+++ b/tests/docs/basic_usage/test_publish_with_ordering.py
@@ -11,7 +11,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestPublishWithOrdering:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_ordering_key_is_forwarded_for_broker_and_publisher(self) -> None:
+    async def test_ordering_key_is_forwarded_for_broker_and_publisher(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_with_broker()
             await publish_with_publisher()
@@ -21,12 +23,18 @@ class TestPublishWithOrdering:
             results = client.get_results()
 
         assert len(published_messages) == 4
-        assert all(message.topic_name == "user-events" for message in published_messages)
+        assert all(
+            message.topic_name == "user-events"
+            for message in published_messages
+        )
         assert [call.kwargs["ordering_key"] for call in publish_calls] == [
             "user-123",
             "user-123",
             "user-123",
             "user-123",
         ]
-        assert all(call.kwargs["attributes"] == {"user_id": "user-123"} for call in publish_calls)
+        assert all(
+            call.kwargs["attributes"] == {"user_id": "user-123"}
+            for call in publish_calls
+        )
         assert all(result.error is None for result in results)

--- a/tests/docs/basic_usage/test_publisher_dependency_injection.py
+++ b/tests/docs/basic_usage/test_publisher_dependency_injection.py
@@ -1,7 +1,10 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from docs.snippets.basic_usage.e2_04_publisher_dependency_injection import app, broker
+from docs.snippets.basic_usage.e2_04_publisher_dependency_injection import (
+    app,
+    broker,
+)
 from fastpubsub.testing import PubSubTestClient
 
 client = TestClient(app)
@@ -10,9 +13,13 @@ client = TestClient(app)
 class TestPublisherDependencyInjection:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_new_user_endpoint_runs_use_case_and_publishes_event(self) -> None:
+    async def test_new_user_endpoint_runs_use_case_and_publishes_event(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as broker_client:
-            response = client.post("/new-user", json={"name": "Alice", "age": 22})
+            response = client.post(
+                "/new-user", json={"name": "Alice", "age": 22}
+            )
             published_messages = broker_client.get_published_messages()
             results = broker_client.get_results()
 

--- a/tests/docs/basic_usage/test_push_subscriber.py
+++ b/tests/docs/basic_usage/test_push_subscriber.py
@@ -30,4 +30,7 @@ class TestPushSubscription:
 
         assert response_content["status"] == "ok"
         assert response_content["processed_data"] == message_content["data"]
-        assert response_content["processed_attributes"] == message_content["attributes"]
+        assert (
+            response_content["processed_attributes"]
+            == message_content["attributes"]
+        )

--- a/tests/docs/basic_usage/test_subscribers_max_messages.py
+++ b/tests/docs/basic_usage/test_subscribers_max_messages.py
@@ -28,7 +28,10 @@ class TestSubscribersMaxMessages:
             results = client.get_results()
 
         assert len(published_messages) == MAX_MESSAGES * 5
-        assert all(message.topic_name == "test-topic" for message in published_messages)
+        assert all(
+            message.topic_name == "test-topic"
+            for message in published_messages
+        )
         assert len(results) == MAX_MESSAGES * 5
         assert all(result.error is None for result in results)
         assert sleep.await_count == MAX_MESSAGES * 5

--- a/tests/docs/integrations/test_fastapi.py
+++ b/tests/docs/integrations/test_fastapi.py
@@ -12,10 +12,16 @@ client = TestClient(app)
 class TestIntegrationsFastapi:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_tasks_endpoint_and_related_routes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_tasks_endpoint_and_related_routes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         async with PubSubTestClient(broker) as broker_client:
-            task_response = client.post("/tasks/", json={"user_id": 10, "task_name": "ship"})
-            order_response = client.post("/new-orders/", json={"product_id": "p-1", "quantity": 2})
+            task_response = client.post(
+                "/tasks/", json={"user_id": 10, "task_name": "ship"}
+            )
+            order_response = client.post(
+                "/new-orders/", json={"product_id": "p-1", "quantity": 2}
+            )
             status_response = client.get("/api/v1/status")
 
             published_messages = broker_client.get_published_messages()
@@ -25,7 +31,10 @@ class TestIntegrationsFastapi:
         assert task_response.json() == {"message": "Task accepted"}
 
         assert order_response.status_code == 200
-        assert order_response.json() == {"order_id": "order-123", "status": "created"}
+        assert order_response.json() == {
+            "order_id": "order-123",
+            "status": "created",
+        }
 
         assert status_response.status_code == 200
         assert status_response.json() == {"status": "healthy"}
@@ -49,9 +58,14 @@ class TestIntegrationsFastapi:
     @pytest.mark.docs
     async def test_orders_endpoint_rejects_non_positive_quantity(self) -> None:
         async with PubSubTestClient(broker) as broker_client:
-            response = client.post("/orders/", json={"product_id": "p-1", "quantity": 0})
+            response = client.post(
+                "/orders/", json={"product_id": "p-1", "quantity": 0}
+            )
             published_messages = broker_client.get_published_messages()
 
         assert not published_messages
         assert response.status_code == UNPROCESSABLE_ENTITY
-        assert any(error["loc"][-1] == "quantity" for error in response.json()["detail"])
+        assert any(
+            error["loc"][-1] == "quantity"
+            for error in response.json()["detail"]
+        )

--- a/tests/docs/integrations/test_pydantic.py
+++ b/tests/docs/integrations/test_pydantic.py
@@ -20,7 +20,9 @@ client = TestClient(app)
 class TestIntegrationsPydantic:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_create_order_publishes_model_and_returns_created(self) -> None:
+    async def test_create_order_publishes_model_and_returns_created(
+        self,
+    ) -> None:
         payload = {
             "order_id": "ord-1",
             "customer_id": "cust-1",
@@ -42,7 +44,10 @@ class TestIntegrationsPydantic:
         published_message = next(iter(published_messages))
 
         assert published_message.topic_name == "orders"
-        assert published_message.data.decode() == OrderEvent(**payload).model_dump_json()
+        assert (
+            published_message.data.decode()
+            == OrderEvent(**payload).model_dump_json()
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.docs
@@ -50,7 +55,9 @@ class TestIntegrationsPydantic:
         self,
     ) -> None:
         async with PubSubTestClient(broker) as broker_client:
-            await broker_client.publish(topic="user-events", data={"user_id": "u-1"})
+            await broker_client.publish(
+                topic="user-events", data={"user_id": "u-1"}
+            )
             processed_results = broker_client.get_results()
 
         assert len(processed_results) == 1
@@ -61,7 +68,9 @@ class TestIntegrationsPydantic:
         assert "Invalid user event" in str(processed_result.error)
 
     @pytest.mark.docs
-    def test_push_endpoint_decodes_base64_and_invokes_process_event(self) -> None:
+    def test_push_endpoint_decodes_base64_and_invokes_process_event(
+        self,
+    ) -> None:
         payload = {
             "order_id": "ord-2",
             "customer_id": "cust-2",
@@ -94,5 +103,7 @@ class TestIntegrationsPydantic:
         flexible = FlexibleEvent.model_validate(payload)
         assert flexible.model_dump() == {"order_id": "ord-3"}
 
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        with pytest.raises(
+            ValidationError, match="Extra inputs are not permitted"
+        ):
             StrictEvent.model_validate(payload)

--- a/tests/docs/middlewares/test_broker_level_middleware.py
+++ b/tests/docs/middlewares/test_broker_level_middleware.py
@@ -1,13 +1,18 @@
 import pytest
 
-from docs.snippets.middlewares.e4_02_broker_level_middleware import broker, publish_first_message
+from docs.snippets.middlewares.e4_02_broker_level_middleware import (
+    broker,
+    publish_first_message,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestMiddlewaresBrokerLevel:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_broker_level_middleware_applies_to_subscriber_processing(self) -> None:
+    async def test_broker_level_middleware_applies_to_subscriber_processing(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_first_message()
             published_messages = client.get_published_messages()

--- a/tests/docs/middlewares/test_common_middlewares.py
+++ b/tests/docs/middlewares/test_common_middlewares.py
@@ -1,6 +1,9 @@
 import pytest
 
-from docs.snippets.middlewares.e1_01_common_middlewares import broker, publish_first_message
+from docs.snippets.middlewares.e1_01_common_middlewares import (
+    broker,
+    publish_first_message,
+)
 from fastpubsub.middlewares import GZipMiddleware
 from fastpubsub.testing import PubSubTestClient
 
@@ -8,7 +11,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestMiddlewaresCommon:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_gzip_middleware_compresses_publish_path_and_processes_message(self) -> None:
+    async def test_gzip_middleware_successfully_executes(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_first_message()
             published_messages = client.get_published_messages()
@@ -27,10 +32,14 @@ class TestMiddlewaresCommon:
 
         assert processed_result.error is None
         assert processed_result.message.attributes is not None
-        assert processed_result.message.attributes["content-encoding"] == "gzip"
+        assert (
+            processed_result.message.attributes["content-encoding"] == "gzip"
+        )
 
     @pytest.mark.docs
-    def test_gzip_middleware_configuration_is_registered_with_expected_level(self) -> None:
+    def test_gzip_middleware_configuration_is_registered_with_expected_level(
+        self,
+    ) -> None:
         middlewares = broker.router.middlewares
         cls, _, kwargs = iter(middlewares[0])
 

--- a/tests/docs/middlewares/test_full_logging_middleware.py
+++ b/tests/docs/middlewares/test_full_logging_middleware.py
@@ -1,13 +1,18 @@
 import pytest
 
-from docs.snippets.middlewares.e4_01_full_logging_middleware import broker, publish_first_message
+from docs.snippets.middlewares.e4_01_full_logging_middleware import (
+    broker,
+    publish_first_message,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestMiddlewaresFullLogging:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_full_logging_middleware_adds_trace_id_and_processes_message(self) -> None:
+    async def test_full_logging_middleware_adds_trace_id_and_processes_message(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_first_message()
             published_messages = client.get_published_messages()

--- a/tests/docs/middlewares/test_publisher_level_middleware.py
+++ b/tests/docs/middlewares/test_publisher_level_middleware.py
@@ -1,13 +1,18 @@
 import pytest
 
-from docs.snippets.middlewares.e4_05_publisher_level_middleware import broker, publish_with_trace
+from docs.snippets.middlewares.e4_05_publisher_level_middleware import (
+    broker,
+    publish_with_trace,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestMiddlewaresPublisherLevel:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_publisher_level_middleware_mutates_attributes_for_custom_publisher(self) -> None:
+    async def test_publisher_middleware_exclusive_to_publisher(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_with_trace()
             published_messages = client.get_published_messages()
@@ -21,8 +26,13 @@ class TestMiddlewaresPublisherLevel:
 
         assert published_message.topic_name == "events"
         assert published_message.attributes is not None
-        assert published_message.attributes["x-trace-id"] == "generated-trace-id"
+        assert (
+            published_message.attributes["x-trace-id"] == "generated-trace-id"
+        )
 
         assert processed_result.error is None
         assert processed_result.message.attributes is not None
-        assert processed_result.message.attributes["x-trace-id"] == "generated-trace-id"
+        assert (
+            processed_result.message.attributes["x-trace-id"]
+            == "generated-trace-id"
+        )

--- a/tests/docs/middlewares/test_router_level_middleware.py
+++ b/tests/docs/middlewares/test_router_level_middleware.py
@@ -1,13 +1,18 @@
 import pytest
 
-from docs.snippets.middlewares.e4_03_router_level_middleware import broker, publish_first_message
+from docs.snippets.middlewares.e4_03_router_level_middleware import (
+    broker,
+    publish_first_message,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestMiddlewaresRouterLevel:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_router_level_middleware_processes_router_subscriber_messages(self) -> None:
+    async def test_router_middleware_exclusive_to_router_children(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_first_message()
             published_messages = client.get_published_messages()
@@ -22,4 +27,6 @@ class TestMiddlewaresRouterLevel:
         assert published_message.topic_name == "users-topic"
 
         assert processed_result.error is None
-        assert processed_result.message.subscriber_name == "handle_user_created"
+        assert (
+            processed_result.message.subscriber_name == "handle_user_created"
+        )

--- a/tests/docs/middlewares/test_subscriber_level_middleware.py
+++ b/tests/docs/middlewares/test_subscriber_level_middleware.py
@@ -10,7 +10,7 @@ from fastpubsub.testing import PubSubTestClient
 class TestMiddlewaresSubscriberLevel:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_subscriber_level_middleware_processes_messages_for_target_subscriber(
+    async def test_subscriber_level_middleware_is_exclusive(
         self,
     ) -> None:
         async with PubSubTestClient(broker) as client:

--- a/tests/docs/observability/test_cloud_logging.py
+++ b/tests/docs/observability/test_cloud_logging.py
@@ -11,14 +11,18 @@ SNIPPET_MODULE = "docs.snippets.observability.e1_02_cloud_logging"
 
 
 class TestObservabilityCloudLogging:
-    def install_fake_google_cloud_logging(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    def install_fake_google_cloud_logging(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> MagicMock:
         sys.modules.pop(SNIPPET_MODULE, None)
 
         fake_client_cls = MagicMock()
 
         logging_module = types.ModuleType("google.cloud.logging")
         logging_module.Client = fake_client_cls
-        monkeypatch.setitem(sys.modules, "google.cloud.logging", logging_module)
+        monkeypatch.setitem(
+            sys.modules, "google.cloud.logging", logging_module
+        )
 
         cloud_module = types.ModuleType("google.cloud")
         cloud_module.__path__ = []

--- a/tests/docs/observability/test_logging_basics.py
+++ b/tests/docs/observability/test_logging_basics.py
@@ -9,7 +9,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestObservabilityLoggingBasics:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_basic_logger_subscriber_processes_message_without_errors(self) -> None:
+    async def test_basic_logger_subscriber_processes_message_without_errors(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await client.publish(topic="tasks", data={"task": "send-email"})
             processed_results = client.get_results()

--- a/tests/docs/routers/test_cross_project_router_simple.py
+++ b/tests/docs/routers/test_cross_project_router_simple.py
@@ -7,11 +7,17 @@ from fastpubsub.testing import PubSubTestClient
 class TestRoutersCrossProjectRouterSimple:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_cross_project_router_only_consumes_messages_for_router_project(self) -> None:
+    async def test_cross_project_message_consumption_isolation(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
-            await client.publish(topic="events", data={"event": "default-project"})
             await client.publish(
-                topic="events", data={"event": "project-b"}, project_id="project-b"
+                topic="events", data={"event": "default-project"}
+            )
+            await client.publish(
+                topic="events",
+                data={"event": "project-b"},
+                project_id="project-b",
             )
             published_messages = client.get_published_messages()
             processed_results = client.get_results()
@@ -28,5 +34,7 @@ class TestRoutersCrossProjectRouterSimple:
         ]
 
         assert processed_result.error is None
-        assert processed_result.message.subscriber_name == "handle_external_event"
+        assert (
+            processed_result.message.subscriber_name == "handle_external_event"
+        )
         assert processed_result.message.project_id == "project-b"

--- a/tests/docs/routers/test_multidomain_routers.py
+++ b/tests/docs/routers/test_multidomain_routers.py
@@ -10,7 +10,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestRoutersMultiDomainMain:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_main_broker_routes_user_and_post_messages_to_domain_handlers(self) -> None:
+    async def test_broker_routes_messages_to_domain_handlers(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_test_messages()
 
@@ -21,7 +23,9 @@ class TestRoutersMultiDomainMain:
         assert len(processed_results) == 2
 
         topics = [result.message.topic_name for result in processed_results]
-        subscribers = {result.message.subscriber_name for result in processed_results}
+        subscribers = {
+            result.message.subscriber_name for result in processed_results
+        }
 
         assert topics == ["users-topic", "posts-topic"]
         assert subscribers == {"handle_user_message", "handle_post_message"}

--- a/tests/docs/routers/test_nested_routers_financial.py
+++ b/tests/docs/routers/test_nested_routers_financial.py
@@ -1,13 +1,18 @@
 import pytest
 
-from docs.snippets.routers.e1_02_nested_routers_financial import broker, publish_test_messages
+from docs.snippets.routers.e1_02_nested_routers_financial import (
+    broker,
+    publish_test_messages,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestRoutersNestedRoutersFinancial:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_nested_router_handlers_receive_messages_for_each_domain(self) -> None:
+    async def test_nested_router_handlers_receive_messages_for_each_domain(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await publish_test_messages()
 
@@ -20,7 +25,9 @@ class TestRoutersNestedRoutersFinancial:
         assert len(processed_results) == 3
 
         topics = [result.message.topic_name for result in processed_results]
-        subscribers_names = {result.message.subscriber_name for result in processed_results}
+        subscribers_names = {
+            result.message.subscriber_name for result in processed_results
+        }
 
         assert topics == [
             "core-topic",

--- a/tests/docs/routers/test_prefix_resolution.py
+++ b/tests/docs/routers/test_prefix_resolution.py
@@ -7,9 +7,13 @@ from fastpubsub.testing import PubSubTestClient
 class TestRoutersPrefixResolution:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_empty_prefix_routers_route_message_with_unique_aliases(self) -> None:
+    async def test_empty_prefix_routers_route_message_with_unique_aliases(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
-            await client.publish(topic="test-router-topic", data={"hello": "world"})
+            await client.publish(
+                topic="test-router-topic", data={"hello": "world"}
+            )
             published_messages = client.get_published_messages()
             processed_results = client.get_results()
 
@@ -17,7 +21,9 @@ class TestRoutersPrefixResolution:
         assert len(processed_results) == 2
 
         published_message = next(iter(published_messages))
-        subscribers = {result.message.subscriber_name for result in processed_results}
+        subscribers = {
+            result.message.subscriber_name for result in processed_results
+        }
 
         assert published_message.topic_name == "test-router-topic"
         assert subscribers == {

--- a/tests/docs/routers/test_prefix_resolution_fails.py
+++ b/tests/docs/routers/test_prefix_resolution_fails.py
@@ -1,7 +1,11 @@
 import pytest
 
-from docs.snippets.routers.e2_03_prefix_resolution_fails import broker as first_broker
-from docs.snippets.routers.e3_03_prefix_resolution_fails import broker as second_broker
+from docs.snippets.routers.e2_03_prefix_resolution_fails import (
+    broker as first_broker,
+)
+from docs.snippets.routers.e3_03_prefix_resolution_fails import (
+    broker as second_broker,
+)
 from fastpubsub.broker import PubSubBroker
 from fastpubsub.exceptions import FastPubSubException
 

--- a/tests/docs/routers/test_router_middlewares.py
+++ b/tests/docs/routers/test_router_middlewares.py
@@ -1,21 +1,30 @@
 import pytest
 
-from docs.snippets.routers.e1_03_router_middlewares import DomainLoggingMiddleware, broker
+from docs.snippets.routers.e1_03_router_middlewares import (
+    DomainLoggingMiddleware,
+    broker,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
 class TestRoutersRouterMiddlewares:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_router_middlewares_apply_to_all_router_subscribers(self) -> None:
+    async def test_router_middlewares_apply_to_all_router_subscribers(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await client.publish(topic="users-topic", data={"user": "alice"})
-            await client.publish(topic="users-deleted-topic", data={"user": "alice"})
+            await client.publish(
+                topic="users-deleted-topic", data={"user": "alice"}
+            )
             processed_results = client.get_results()
 
         assert len(processed_results) == 2
 
-        subscribers = {result.message.subscriber_name for result in processed_results}
+        subscribers = {
+            result.message.subscriber_name for result in processed_results
+        }
         assert subscribers == {
             "handle_user_created",
             "handle_user_deleted",
@@ -24,7 +33,9 @@ class TestRoutersRouterMiddlewares:
         assert all(result.error is None for result in processed_results)
 
     @pytest.mark.docs
-    def test_router_middleware_registration_propagates_into_subscribers(self) -> None:
+    def test_router_middleware_registration_propagates_into_subscribers(
+        self,
+    ) -> None:
         subscribers = broker.router._get_subscribers()
 
         subscriber_created = subscribers["users.created"]

--- a/tests/docs/testing/test_processed_messages.py
+++ b/tests/docs/testing/test_processed_messages.py
@@ -24,7 +24,9 @@ class TestTestingProcessedMessages:
 
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_processed_result_records_error_for_invalid_order(self) -> None:
+    async def test_processed_result_records_error_for_invalid_order(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await client.publish(
                 {"id": "order-2", "amount": -5},

--- a/tests/docs/testing/test_setup_async.py
+++ b/tests/docs/testing/test_setup_async.py
@@ -1,6 +1,8 @@
 import pytest
 
-from docs.snippets.testing.e1_01_setup_asyncio import test_example as asyncio_test
+from docs.snippets.testing.e1_01_setup_asyncio import (
+    test_example as asyncio_test,
+)
 
 
 class TestTestingSetupAsyncio:
@@ -13,7 +15,9 @@ class TestTestingSetupAsyncio:
 
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_anyio_setup_example_runs_successfully_under_asyncio(self) -> None:
+    async def test_anyio_setup_example_runs_successfully_under_asyncio(
+        self,
+    ) -> None:
         # If it runs it works.
         # Wrapped tests always return None
         assert await asyncio_test() is None

--- a/tests/docs/testing/test_test_published_messages.py
+++ b/tests/docs/testing/test_test_published_messages.py
@@ -7,7 +7,9 @@ from fastpubsub.testing import PubSubTestClient
 class TestTestingPublishedMessages:
     @pytest.mark.asyncio
     @pytest.mark.docs
-    async def test_forwarded_message_is_captured_with_expected_topic_and_data(self) -> None:
+    async def test_forwarded_message_is_captured_with_expected_topic_and_data(
+        self,
+    ) -> None:
         async with PubSubTestClient(broker) as client:
             await client.publish("order-123", topic="incoming-orders")
             published_messages = client.get_published_messages()

--- a/tests/docs/troubleshooting/test_common_patterns.py
+++ b/tests/docs/troubleshooting/test_common_patterns.py
@@ -62,7 +62,9 @@ class TestTroubleshootingCommonPatterns:
     @pytest.mark.docs
     async def test_validated_handler_drops_invalid_message(self) -> None:
         async with PubSubTestClient(broker) as client:
-            await client.publish(topic="validated-events", data={"wrong": "shape"})
+            await client.publish(
+                topic="validated-events", data={"wrong": "shape"}
+            )
             results = client.get_results()
 
         assert len(results) == 1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,9 @@ async def cleanup_resources(
     # Cleanup subscription
     try:
         sub_client = SubscriberClient()
-        sub_path = sub_client.subscription_path(project_id, unique_subscription)
+        sub_path = sub_client.subscription_path(
+            project_id, unique_subscription
+        )
         sub_client.delete_subscription(request={"subscription": sub_path})
     except Exception:
         pass  # Ignore cleanup errors
@@ -75,7 +77,9 @@ async def connected_broker(
     # Cleanup subscription
     try:
         sub_client = SubscriberClient()
-        sub_path = sub_client.subscription_path(project_id, unique_subscription)
+        sub_path = sub_client.subscription_path(
+            project_id, unique_subscription
+        )
         sub_client.delete_subscription(request={"subscription": sub_path})
     except Exception:
         pass  # Ignore cleanup errors

--- a/tests/integration/test_consume_messages.py
+++ b/tests/integration/test_consume_messages.py
@@ -74,9 +74,15 @@ class TestMessageConsumption:
                 event.set()
 
         async with managed_broker(connected_broker):
-            await connected_broker.publish(topic_name=unique_topic, data="Message 1")
-            await connected_broker.publish(topic_name=unique_topic, data="Message 2")
-            await connected_broker.publish(topic_name=unique_topic, data="Message 3")
+            await connected_broker.publish(
+                topic_name=unique_topic, data="Message 1"
+            )
+            await connected_broker.publish(
+                topic_name=unique_topic, data="Message 2"
+            )
+            await connected_broker.publish(
+                topic_name=unique_topic, data="Message 3"
+            )
 
             await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
@@ -109,7 +115,9 @@ class TestMessageConsumption:
         message_quantity = 3
         async with managed_broker(connected_broker):
             for i in range(message_quantity):
-                await connected_broker.publish(topic_name=unique_topic, data=f"Message {i}")
+                await connected_broker.publish(
+                    topic_name=unique_topic, data=f"Message {i}"
+                )
             # Give some time to start processing
             await asyncio.sleep(2)
 

--- a/tests/integration/test_exception_handling.py
+++ b/tests/integration/test_exception_handling.py
@@ -86,7 +86,9 @@ class TestExceptionHandling:
             )
 
             await asyncio.sleep(7.0)
-            assert received.qsize() == 1, "Message should only be processed once"
+            assert received.qsize() == 1, (
+                "Message should only be processed once"
+            )
 
     @pytest.mark.asyncio
     @pytest.mark.slow
@@ -112,5 +114,7 @@ class TestExceptionHandling:
             completed.set()
 
         async with managed_broker(connected_broker):
-            await connected_broker.publish(topic_name=unique_topic, data="test")
+            await connected_broker.publish(
+                topic_name=unique_topic, data="test"
+            )
             await asyncio.wait_for(completed.wait(), timeout=self.timeout)

--- a/tests/integration/test_graceful_shutdown.py
+++ b/tests/integration/test_graceful_shutdown.py
@@ -45,7 +45,9 @@ class TestGracefulShutdown:
         await connected_broker.start()
 
         # Publish a message
-        await connected_broker.publish(topic_name=unique_topic, data=b"test-message-1")
+        await connected_broker.publish(
+            topic_name=unique_topic, data=b"test-message-1"
+        )
 
         # Wait for processing to start
         await asyncio.wait_for(processing_started.wait(), timeout=5.0)
@@ -84,7 +86,9 @@ class TestGracefulShutdown:
         await connected_broker.start()
 
         # Publish first message
-        await connected_broker.publish(topic_name=unique_topic, data=b"message-1")
+        await connected_broker.publish(
+            topic_name=unique_topic, data=b"message-1"
+        )
 
         # Wait for first message to be received
         await asyncio.wait_for(first_message_received.wait(), timeout=5.0)
@@ -96,8 +100,12 @@ class TestGracefulShutdown:
         await asyncio.sleep(0.2)
 
         # Publish more messages (these should be nacked by closed scheduler)
-        await connected_broker.publish(topic_name=unique_topic, data=b"message-2")
-        await connected_broker.publish(topic_name=unique_topic, data=b"message-3")
+        await connected_broker.publish(
+            topic_name=unique_topic, data=b"message-2"
+        )
+        await connected_broker.publish(
+            topic_name=unique_topic, data=b"message-3"
+        )
 
         # Wait for shutdown to complete
         await shutdown_task
@@ -227,7 +235,9 @@ class TestGracefulShutdown:
         await connected_broker.start()
 
         # Publish a message
-        await connected_broker.publish(topic_name=unique_topic, data=b"test-message")
+        await connected_broker.publish(
+            topic_name=unique_topic, data=b"test-message"
+        )
 
         # Wait for message
         await asyncio.sleep(1.0)

--- a/tests/integration/test_middlewares.py
+++ b/tests/integration/test_middlewares.py
@@ -56,11 +56,17 @@ class TestMiddlewares:
             event.set()
 
         async with managed_broker(connected_broker):
-            await connected_broker.publish(topic_name=unique_topic, data="test message")
+            await connected_broker.publish(
+                topic_name=unique_topic, data="test message"
+            )
             await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
             calls = [call[0][0] for call in mock.call_args_list]
-            assert calls == ["logging_middleware", "validation_middleware", "handler"]
+            assert calls == [
+                "logging_middleware",
+                "validation_middleware",
+                "handler",
+            ]
 
     @pytest.mark.asyncio
     async def test_subscriber_specific_middleware(
@@ -89,7 +95,9 @@ class TestMiddlewares:
             event.set()
 
         async with managed_broker(connected_broker):
-            await connected_broker.publish(topic_name=unique_topic, data="test")
+            await connected_broker.publish(
+                topic_name=unique_topic, data="test"
+            )
             await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
             calls = [call[0][0] for call in mock.call_args_list]
@@ -111,7 +119,10 @@ class TestMiddlewares:
                 return await super().on_message(message)
 
             async def on_publish(
-                self, data: bytes, ordering_key: str, attributes: dict[str, str] | None
+                self,
+                data: bytes,
+                ordering_key: str,
+                attributes: dict[str, str] | None,
             ) -> Any:
                 if not attributes:
                     attributes = {}
@@ -131,8 +142,12 @@ class TestMiddlewares:
             pass
 
         async with managed_broker(connected_broker):
-            await connected_broker.publish(topic_name=unique_topic, data="test")
-            attributes = await asyncio.wait_for(received.get(), timeout=self.timeout)
+            await connected_broker.publish(
+                topic_name=unique_topic, data="test"
+            )
+            attributes = await asyncio.wait_for(
+                received.get(), timeout=self.timeout
+            )
 
             assert isinstance(attributes, dict)
             assert attributes.get("key") == "value"

--- a/tests/integration/test_publish_messages.py
+++ b/tests/integration/test_publish_messages.py
@@ -47,7 +47,9 @@ class TestMessagePublishing:
                 data=sent_data,
             )
 
-            received_data = await asyncio.wait_for(received.get(), timeout=self.timeout)
+            received_data = await asyncio.wait_for(
+                received.get(), timeout=self.timeout
+            )
             assert received_data == sent_data
 
     @pytest.mark.asyncio
@@ -75,7 +77,9 @@ class TestMessagePublishing:
                 data=sent_data,
             )
 
-            received_data = await asyncio.wait_for(received.get(), timeout=self.timeout)
+            received_data = await asyncio.wait_for(
+                received.get(), timeout=self.timeout
+            )
             assert received_data.decode() == sent_data
 
     @pytest.mark.asyncio
@@ -103,7 +107,9 @@ class TestMessagePublishing:
                 data=sent_data,
             )
 
-            result = await asyncio.wait_for(received.get(), timeout=self.timeout)
+            result = await asyncio.wait_for(
+                received.get(), timeout=self.timeout
+            )
             received_data = json.loads(result.decode())
             assert sent_data == received_data
 
@@ -135,7 +141,9 @@ class TestMessagePublishing:
                 attributes=sent_attributes,
             )
 
-            result = await asyncio.wait_for(received.get(), timeout=self.timeout)
+            result = await asyncio.wait_for(
+                received.get(), timeout=self.timeout
+            )
 
             assert isinstance(result, Message)
             assert result.data == sent_data
@@ -165,12 +173,16 @@ class TestMessagePublishing:
                 attribute_name: str
                 attribute_value: str
 
-            sent_data = SomePydanticModel(attribute_name="car_color", attribute_value="blue")
+            sent_data = SomePydanticModel(
+                attribute_name="car_color", attribute_value="blue"
+            )
             await connected_broker.publish(
                 topic_name=unique_topic,
                 data=sent_data,
             )
 
-            result = await asyncio.wait_for(received.get(), timeout=self.timeout)
+            result = await asyncio.wait_for(
+                received.get(), timeout=self.timeout
+            )
             received_data = SomePydanticModel.model_validate_json(result)
             assert sent_data == received_data

--- a/tests/integration/test_subscription_lifecycle.py
+++ b/tests/integration/test_subscription_lifecycle.py
@@ -43,8 +43,12 @@ class TestSubscriptionLifecycle:
             assert topic_obj.name == topic_path
 
             sub_client = SubscriberClient()
-            sub_path = sub_client.subscription_path(project_id, unique_subscription)
-            sub_obj = sub_client.get_subscription(request={"subscription": sub_path})
+            sub_path = sub_client.subscription_path(
+                project_id, unique_subscription
+            )
+            sub_obj = sub_client.get_subscription(
+                request={"subscription": sub_path}
+            )
             assert sub_obj.name == sub_path
 
     @pytest.mark.asyncio
@@ -106,7 +110,9 @@ class TestSubscriptionLifecycle:
             event_2.set()
 
         async with managed_broker(connected_broker):
-            await connected_broker.publish(topic_name=unique_topic, data="broadcast message")
+            await connected_broker.publish(
+                topic_name=unique_topic, data="broadcast message"
+            )
             await asyncio.wait_for(event_1.wait(), timeout=self.timeout)
             await asyncio.wait_for(event_2.wait(), timeout=self.timeout)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,7 +33,9 @@ def first_middleware() -> type[BaseMiddleware]:
     """Create a FirstMiddleware class for testing."""
 
     class FirstMiddleware(BaseMiddleware):
-        def __init__(self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""):
+        def __init__(
+            self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""
+        ):
             super().__init__(next_call)
             self.arg_1 = arg_1
             self.arg_2 = arg_2
@@ -46,7 +48,9 @@ def second_middleware() -> type[BaseMiddleware]:
     """Create a SecondMiddleware class for testing."""
 
     class SecondMiddleware(BaseMiddleware):
-        def __init__(self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""):
+        def __init__(
+            self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""
+        ):
             super().__init__(next_call)
             self.arg_1 = arg_1
             self.arg_2 = arg_2
@@ -59,7 +63,9 @@ def third_middleware() -> type[BaseMiddleware]:
     """Create a ThirdMiddleware class for testing."""
 
     class ThirdMiddleware(BaseMiddleware):
-        def __init__(self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""):
+        def __init__(
+            self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""
+        ):
             super().__init__(next_call)
             self.arg_1 = arg_1
             self.arg_2 = arg_2
@@ -72,7 +78,9 @@ def final_middleware() -> type[BaseMiddleware]:
     """Create a FinalMiddleware class for testing."""
 
     class FinalMiddleware(BaseMiddleware):
-        def __init__(self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""):
+        def __init__(
+            self, next_call: BaseMiddleware, arg_1: str = "", arg_2: str = ""
+        ):
             super().__init__(next_call)
             self.arg_1 = arg_1
             self.arg_2 = arg_2

--- a/tests/unit/test_applications.py
+++ b/tests/unit/test_applications.py
@@ -20,7 +20,9 @@ def mock_broker() -> MagicMock:
 
 class TestApplicationLifecycle:
     @pytest.mark.asyncio
-    async def test_application_hooks_are_called_on_constructor(self, mock_broker: MagicMock):
+    async def test_application_hooks_are_called_on_constructor(
+        self, mock_broker: MagicMock
+    ):
         on_startup_action = AsyncMock(spec=FunctionType)
         after_startup_action = AsyncMock(spec=FunctionType)
         on_shutdown_action = AsyncMock(spec=FunctionType)
@@ -65,7 +67,9 @@ class TestApplicationLifecycle:
         after_shutdown_mock.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_decorator_hooks_are_called_with_lifespan(self, mock_broker: MagicMock):
+    async def test_decorator_hooks_are_called_with_lifespan(
+        self, mock_broker: MagicMock
+    ):
         start_lifepan_call = MagicMock()
         end_lifepan_call = MagicMock()
 

--- a/tests/unit/test_async_scheduler.py
+++ b/tests/unit/test_async_scheduler.py
@@ -54,8 +54,6 @@ class TestAsyncSchedulerTracking:
     async def test_deregister_executed_task_removes_from_tracking(
         self, scheduler: AsyncScheduler, mock_message: MagicMock
     ):
-        """Test that deregister_executed_task cleans up."""
-
         async def dummy_coro():
             await asyncio.sleep(0.01)
 
@@ -64,21 +62,15 @@ class TestAsyncSchedulerTracking:
         scheduler.register_task_execution(task, mock_message)
         assert id(task) in scheduler._executing_tasks
 
-        # Wait for task to complete (which triggers auto-deregister via done callback)
         await task
-
-        # Small delay to allow done callback to execute
         await asyncio.sleep(0.01)
-
         assert id(task) not in scheduler._executing_tasks
 
     @pytest.mark.asyncio
     async def test_get_in_flight_count_returns_pending_and_executing(
         self, scheduler: AsyncScheduler, mock_message: MagicMock
     ):
-        """Test that get_in_flight_count returns correct counts."""
-
-        def dummy_callback(msg):
+        def dummy_callback(_):
             pass
 
         scheduler.schedule(dummy_callback, mock_message)
@@ -142,7 +134,9 @@ class TestAsyncSchedulerTracking:
         assert scheduler.closed is True
 
     @pytest.mark.asyncio
-    async def test_wait_for_completion_returns_true_on_success(self, scheduler):
+    async def test_wait_for_completion_returns_true_on_success(
+        self, scheduler
+    ):
         """Test that wait_for_completion returns True when all complete."""
 
         result = await scheduler.wait_for_completion(timeout=1.0)

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -39,7 +39,9 @@ class TestPubSubBroker:
             213,
         ],
     )
-    def test_init_with_invalid_project_id_raises_exception(self, invalid_project_id):
+    def test_init_with_invalid_project_id_raises_exception(
+        self, invalid_project_id
+    ):
         with pytest.raises(FastPubSubException):
             PubSubBroker(project_id=invalid_project_id)
 
@@ -89,7 +91,9 @@ class TestPubSubBroker:
         os.environ["FASTPUBSUB_SUBSCRIBERS"] = selected_subscribers
         try:
             mock_router = MagicMock()
-            mock_router._get_subscribers = MagicMock(return_value={"a": "a", "b": "b"})
+            mock_router._get_subscribers = MagicMock(
+                return_value={"a": "a", "b": "b"}
+            )
             broker.router = mock_router
 
             found_subscribers = broker._filter_subscribers()
@@ -97,14 +101,19 @@ class TestPubSubBroker:
             for expected_sub in expected_subscribers:
                 if expected_sub not in found_subscribers:
                     pytest.fail(
-                        reason="The expected subscribers do not "
-                        f"match the filtered ones {expected_subscribers} {found_subscribers}"
+                        reason=(
+                            "The expected subscribers do not "
+                            "match the filtered ones"
+                            f"{expected_subscribers} {found_subscribers}"
+                        )
                     )
         finally:
             os.environ["FASTPUBSUB_SUBSCRIBERS"] = ""
 
     @pytest.mark.asyncio
-    async def test_shutdown_successfully(self, async_task_manager: MagicMock, broker: PubSubBroker):
+    async def test_shutdown_successfully(
+        self, async_task_manager: MagicMock, broker: PubSubBroker
+    ):
         await broker.shutdown()
         async_task_manager.shutdown.assert_called_once()
 
@@ -116,7 +125,10 @@ class TestPubSubBroker:
 
     @pytest.mark.asyncio
     async def test_start_broker(
-        self, subscription_builder: MagicMock, async_task_manager: MagicMock, broker: PubSubBroker
+        self,
+        subscription_builder: MagicMock,
+        async_task_manager: MagicMock,
+        broker: PubSubBroker,
     ):
         expected_subscriber = MagicMock(spec=Subscriber)
         expected_subscriber.project_id = "some_project_id"
@@ -124,7 +136,9 @@ class TestPubSubBroker:
         await broker.start()
 
         subscription_builder.build.assert_called_once_with(expected_subscriber)
-        async_task_manager.create_task.assert_called_once_with(expected_subscriber)
+        async_task_manager.create_task.assert_called_once_with(
+            expected_subscriber
+        )
         async_task_manager.start.assert_called_once()
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_broker_router_include.py
+++ b/tests/unit/test_broker_router_include.py
@@ -9,7 +9,8 @@ def test_router_inclusion_on_constructor():
     another_parent_router = PubSubRouter("another_parent")
 
     broker = PubSubBroker(
-        project_id="some_project_id", routers=(parent_router, another_parent_router)
+        project_id="some_project_id",
+        routers=(parent_router, another_parent_router),
     )
 
     assert len(another_parent_router.routers) == 0
@@ -18,7 +19,12 @@ def test_router_inclusion_on_constructor():
     assert len(parent_router.routers) == 1
     assert len(broker.router.routers) == 2
 
-    routers = (grandchild_router, child_router, parent_router, another_parent_router)
+    routers = (
+        grandchild_router,
+        child_router,
+        parent_router,
+        another_parent_router,
+    )
     for router in routers:
         assert broker.router.project_id == router.project_id
 
@@ -49,7 +55,12 @@ def test_router_inclusion_on_include_router():
     assert len(parent_router.routers) == 1
     assert len(broker.router.routers) == 2
 
-    routers = (grandchild_router, child_router, parent_router, another_parent_router)
+    routers = (
+        grandchild_router,
+        child_router,
+        parent_router,
+        another_parent_router,
+    )
     for router in routers:
         assert broker.router.project_id == router.project_id
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,7 +9,11 @@ from typer.testing import CliRunner
 from fastpubsub.applications import FastPubSub
 from fastpubsub.broker import PubSubBroker
 from fastpubsub.cli.main import app
-from fastpubsub.cli.runner import AppConfiguration, ApplicationRunner, ServerConfiguration
+from fastpubsub.cli.runner import (
+    AppConfiguration,
+    ApplicationRunner,
+    ServerConfiguration,
+)
 from fastpubsub.exceptions import FastPubSubCLIException
 
 runner = CliRunner()
@@ -33,7 +37,9 @@ class TestCLI:
 
     @patch("fastpubsub.cli.main.ensure_pubsub_credentials")
     @patch("fastpubsub.cli.main.ApplicationRunner")
-    def test_run_command(self, mock_runner: MagicMock, mock_ensure_credentials: MagicMock):
+    def test_run_command(
+        self, mock_runner: MagicMock, mock_ensure_credentials: MagicMock
+    ):
         result = runner.invoke(app, ["run", "some_module:app"])
         assert result.exit_code == 0
         mock_runner.assert_called_once()
@@ -84,7 +90,9 @@ class TestCLI:
             reload=True,
             log_level="error",
         )
-        mock_runner_class.assert_called_once_with(expected_app_config, expected_server_config)
+        mock_runner_class.assert_called_once_with(
+            expected_app_config, expected_server_config
+        )
         mock_runner_instance.setup.assert_called_once()
         mock_runner_instance.validate.assert_called_once()
         mock_runner_instance.run.assert_called_once()
@@ -108,32 +116,49 @@ class TestApplicationRunner:
             log_level="INFO",
         )
 
-        runner_instance = ApplicationRunner(app_config=app_config, server_config=server_config)
+        runner_instance = ApplicationRunner(
+            app_config=app_config, server_config=server_config
+        )
         runner_instance.run()
         mock_uvicorn_run.assert_called_once_with(
             app_config.app, lifespan="on", **asdict(server_config)
         )
 
-    @patch("fastpubsub.cli.runner.ApplicationRunner._resolve_application_posix_path")
-    @patch("fastpubsub.cli.runner.ApplicationRunner._translate_pypath_to_posix")
+    @patch(
+        "fastpubsub.cli.runner.ApplicationRunner._resolve_application_posix_path"
+    )
+    @patch(
+        "fastpubsub.cli.runner.ApplicationRunner._translate_pypath_to_posix"
+    )
     @patch("uvicorn.importer.import_from_string")
     def test_validate_application_invalid_app_instance(
-        self, mock_import: MagicMock, mock_translate: MagicMock, mock_resolve: MagicMock
+        self,
+        mock_import: MagicMock,
+        mock_translate: MagicMock,
+        mock_resolve: MagicMock,
     ):
         mock_import.return_value = object()  # Not a FastPubSub instance
         app_config = MagicMock(spec=AppConfiguration)
         app_config.app = "my_app:app"
         runner_instance = ApplicationRunner(
-            app_config=app_config, server_config=MagicMock(spec=ServerConfiguration)
+            app_config=app_config,
+            server_config=MagicMock(spec=ServerConfiguration),
         )
         with pytest.raises(FastPubSubCLIException):
             runner_instance.validate()
 
-    @patch("fastpubsub.cli.runner.ApplicationRunner._resolve_application_posix_path")
-    @patch("fastpubsub.cli.runner.ApplicationRunner._translate_pypath_to_posix")
+    @patch(
+        "fastpubsub.cli.runner.ApplicationRunner._resolve_application_posix_path"
+    )
+    @patch(
+        "fastpubsub.cli.runner.ApplicationRunner._translate_pypath_to_posix"
+    )
     @patch("uvicorn.importer.import_from_string")
     def test_validate_application_valid_app(
-        self, mock_import: MagicMock, mock_translate: MagicMock, mock_resolve: MagicMock
+        self,
+        mock_import: MagicMock,
+        mock_translate: MagicMock,
+        mock_resolve: MagicMock,
     ):
         mock_broker = MagicMock(spec=PubSubBroker)
         mock_import.return_value = FastPubSub(broker=mock_broker)
@@ -141,13 +166,15 @@ class TestApplicationRunner:
         app_config = MagicMock(spec=AppConfiguration)
         app_config.app = "my_app:app"
         runner_instance = ApplicationRunner(
-            app_config=app_config, server_config=MagicMock(spec=ServerConfiguration)
+            app_config=app_config,
+            server_config=MagicMock(spec=ServerConfiguration),
         )
         runner_instance.validate()
 
     def test_translate_pypath_to_posix_invalid_format(self):
         runner_instance = ApplicationRunner(
-            MagicMock(spec=AppConfiguration), MagicMock(spec=ServerConfiguration)
+            MagicMock(spec=AppConfiguration),
+            MagicMock(spec=ServerConfiguration),
         )
         with pytest.raises(uvicorn.importer.ImportFromStringError):
             runner_instance._translate_pypath_to_posix("invalid_path")
@@ -155,7 +182,9 @@ class TestApplicationRunner:
 
 class TestUtils:
     def test_ensure_pubsub_credentials_set(self):
-        with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "fake_credentials"}):
+        with patch.dict(
+            os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "fake_credentials"}
+        ):
             from fastpubsub.cli.utils import ensure_pubsub_credentials
 
             ensure_pubsub_credentials()

--- a/tests/unit/test_concurrency_utils.py
+++ b/tests/unit/test_concurrency_utils.py
@@ -48,9 +48,13 @@ class TestEnsureAsyncMiddleware:
             SyncOnPublishMiddleware,
         ],
     )
-    def test_with_invalid_middleware_raises_exception(self, invalid_middleware):
+    def test_with_invalid_middleware_raises_exception(
+        self, invalid_middleware
+    ):
         with pytest.raises(TypeError):
             ensure_async_middleware(invalid_middleware)
 
-    def test_with_valid_middleware_succeeds(self, first_middleware: type[BaseMiddleware]):
+    def test_with_valid_middleware_succeeds(
+        self, first_middleware: type[BaseMiddleware]
+    ):
         ensure_async_middleware(first_middleware)

--- a/tests/unit/test_cross_project_support.py
+++ b/tests/unit/test_cross_project_support.py
@@ -12,11 +12,15 @@ class TestCrossProjectSupport:
         router = PubSubRouter(project_id="ProjectB")
         broker.include_router(router)
 
-        @broker.subscriber("sub_a", topic_name="topic_a", subscription_name="sub_a")
+        @broker.subscriber(
+            "sub_a", topic_name="topic_a", subscription_name="sub_a"
+        )
         async def sub_a(msg):
             pass
 
-        @router.subscriber("sub_b", topic_name="topic_b", subscription_name="sub_b")
+        @router.subscriber(
+            "sub_b", topic_name="topic_b", subscription_name="sub_b"
+        )
         async def sub_b(msg):
             pass
 
@@ -35,18 +39,25 @@ class TestCrossProjectSupport:
     def test_pubsub_project_broker_overrides(self):
         broker = PubSubBroker(project_id="ProjectA")
 
-        @broker.subscriber("sub_a", topic_name="topic_a", subscription_name="sub_a")
+        @broker.subscriber(
+            "sub_a", topic_name="topic_a", subscription_name="sub_a"
+        )
         async def default_sub_handler(msg):
             pass
 
         @broker.subscriber(
-            "sub_b", topic_name="topic_b", subscription_name="sub_b", project_id="ProjectB"
+            "sub_b",
+            topic_name="topic_b",
+            subscription_name="sub_b",
+            project_id="ProjectB",
         )
         async def another_project_sub_handler(msg):
             pass
 
         default_project_publisher = broker.publisher("topic_a")
-        specific_project_publisher = broker.publisher("topic_c", project_id="ProjectC")
+        specific_project_publisher = broker.publisher(
+            "topic_c", project_id="ProjectC"
+        )
 
         default_project_subscriber = broker.router.subscribers["sub_a"]
         specific_project_subscriber = broker.router.subscribers["sub_b"]
@@ -59,12 +70,16 @@ class TestCrossProjectSupport:
 
     @pytest.mark.asyncio
     @patch("fastpubsub.router.Publisher")
-    async def test_case_broker_publish_override_project_id(self, MockPublisher):
+    async def test_case_broker_publish_override_project_id(
+        self, MockPublisher
+    ):
         broker = PubSubBroker(project_id="ProjectA")
         mock_pub_instance = MockPublisher.return_value
         mock_pub_instance.publish = AsyncMock()
 
-        await broker.publish("topic_b", {"data": "test"}, project_id="ProjectB")
+        await broker.publish(
+            "topic_b", {"data": "test"}, project_id="ProjectB"
+        )
         MockPublisher.assert_called_with(
             topic_name="topic_b", project_id="ProjectB", middlewares=[]
         )

--- a/tests/unit/test_middleware_include_hierarchy.py
+++ b/tests/unit/test_middleware_include_hierarchy.py
@@ -24,13 +24,21 @@ class TestMiddlewareHierarchy:
         router_a.include_middleware(middleware=second_middleware)
         broker.include_middleware(middleware=first_middleware)
 
-    def test_include_broker_middleware_only_once(self, first_middleware: type[BaseMiddleware]):
-        new_broker = PubSubBroker(project_id="id", middlewares=(Middleware(first_middleware),))
+    def test_include_broker_middleware_only_once(
+        self, first_middleware: type[BaseMiddleware]
+    ):
+        new_broker = PubSubBroker(
+            project_id="id", middlewares=(Middleware(first_middleware),)
+        )
         new_broker.include_middleware(middleware=first_middleware)
         assert len(new_broker.router.middlewares) == 1
 
-    def test_include_router_middleware_only_once(self, first_middleware: type[BaseMiddleware]):
-        router = PubSubRouter(prefix="core", middlewares=(Middleware(first_middleware),))
+    def test_include_router_middleware_only_once(
+        self, first_middleware: type[BaseMiddleware]
+    ):
+        router = PubSubRouter(
+            prefix="core", middlewares=(Middleware(first_middleware),)
+        )
         router.include_middleware(first_middleware)
 
         broker = PubSubBroker(project_id="id")
@@ -173,7 +181,9 @@ class TestSubscriberPublisherMiddlewareHierarchy(TestMiddlewareHierarchy):
 
         publisher_b: Publisher = router_b.publisher(topic_name="some_topic")
         publisher_a: Publisher = router_a.publisher(topic_name="another_topic")
-        publisher_broker: Publisher = broker.publisher(topic_name="final_ttoic")
+        publisher_broker: Publisher = broker.publisher(
+            topic_name="final_ttoic"
+        )
 
         publisher_b.include_middleware(final_middleware)
         publisher_a.include_middleware(final_middleware)

--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -19,7 +19,10 @@ class MockMiddleware(BaseMiddleware):
         return await super().on_message(message)
 
     async def on_publish(
-        self, data: bytes, ordering_key: str | None, attributes: dict[str, str] | None
+        self,
+        data: bytes,
+        ordering_key: str | None,
+        attributes: dict[str, str] | None,
     ):
         self.published_message, self.published_attributes = data, attributes
         return await super().on_publish(data, ordering_key, attributes)

--- a/tests/unit/test_publish_message.py
+++ b/tests/unit/test_publish_message.py
@@ -12,9 +12,16 @@ from fastpubsub.router import PubSubRouter
 class TestPublishMessage:
     @pytest.mark.asyncio
     async def test_publish_with_all_fields_successfully(
-        self, router_a: PubSubRouter, broker: PubSubBroker, publisher: Publisher
+        self,
+        router_a: PubSubRouter,
+        broker: PubSubBroker,
+        publisher: Publisher,
     ):
-        data = {"data": b"data", "ordering_key": "key", "attributes": {"attr1": "val1"}}
+        data = {
+            "data": b"data",
+            "ordering_key": "key",
+            "attributes": {"attr1": "val1"},
+        }
 
         with patch.object(
             Publisher, "_build_callstack", return_value=AsyncMock()
@@ -43,7 +50,11 @@ class TestPublishMessage:
         [
             {"data": True},
             {"data": 101, "ordering_key": "key"},
-            {"data": "text", "ordering_key": {}, "attributes": {"key": "value"}},
+            {
+                "data": "text",
+                "ordering_key": {},
+                "attributes": {"key": "value"},
+            },
             {"data": "text", "attributes": {"key": object}},
             {"data": "text", "autocreate": None},
         ],

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -28,7 +28,10 @@ class ComplexMessageSchema(BaseModel):
 
 class TestPublisher:
     def test_create_publisher_instances(
-        self, router_a: PubSubRouter, router_b: PubSubRouter, broker: PubSubBroker
+        self,
+        router_a: PubSubRouter,
+        router_b: PubSubRouter,
+        broker: PubSubBroker,
     ):
         first_publisher = router_a.publisher("topic")
         second_publisher = router_b.publisher("topic")
@@ -68,7 +71,10 @@ class TestPublisher:
         callstack_b = message_publisher_b._build_callstack()
         callstack_c = message_publisher_c._build_callstack()
 
-        expected_output_a = [first_middleware, PublishMessageSerializerMiddleware]
+        expected_output_a = [
+            first_middleware,
+            PublishMessageSerializerMiddleware,
+        ]
         assert callstack_matches(callstack_a, expected_output_a)
 
         expected_output_b = [
@@ -78,7 +84,10 @@ class TestPublisher:
         ]
         assert callstack_matches(callstack_b, expected_output_b)
 
-        expected_output_c = [first_middleware, PublishMessageSerializerMiddleware]
+        expected_output_c = [
+            first_middleware,
+            PublishMessageSerializerMiddleware,
+        ]
         assert callstack_matches(callstack_c, expected_output_c)
 
     def test_build_callstack_with_parameters(
@@ -88,9 +97,15 @@ class TestPublisher:
         first_middleware: type[BaseMiddleware],
         second_middleware: type[BaseMiddleware],
     ):
-        broker.include_middleware(first_middleware, "broker_arg", arg_2="broker_kwarg")
-        broker.include_middleware(second_middleware, arg_2="broker_kwargs_only")
-        router_a.include_middleware(first_middleware, "router_arg", arg_2="router_kwarg")
+        broker.include_middleware(
+            first_middleware, "broker_arg", arg_2="broker_kwarg"
+        )
+        broker.include_middleware(
+            second_middleware, arg_2="broker_kwargs_only"
+        )
+        router_a.include_middleware(
+            first_middleware, "router_arg", arg_2="router_kwarg"
+        )
         router_a.include_middleware(second_middleware, "router_arg_only")
         broker.include_router(router_a)
 
@@ -140,7 +155,9 @@ class TestPublisher:
         ]
 
         router = PubSubRouter(middlewares=router_middlewares)
-        broker = PubSubBroker("some_project", routers=[router], middlewares=broker_middlewares)
+        broker = PubSubBroker(
+            "some_project", routers=[router], middlewares=broker_middlewares
+        )
 
         broker_publisher = broker.publisher(topic_name="somerandomtopic")
         broker_callstack = broker_publisher._build_callstack()
@@ -207,7 +224,9 @@ class TestPublisherSerialization:
         assert message.model_dump() == deserialized_message
 
     @pytest.mark.asyncio
-    async def test_serialize_complex_pydantic_model(self, publisher: Publisher):
+    async def test_serialize_complex_pydantic_model(
+        self, publisher: Publisher
+    ):
         message = ComplexMessageSchema(
             event_id=uuid4(),
             timestamp=datetime.now(),
@@ -221,7 +240,9 @@ class TestPublisherSerialization:
     @pytest.mark.asyncio
     async def test_serialize_text(self, publisher: Publisher):
         message = "some_text_string"
-        serialized_message = await publisher._serialize_message("some_text_string")
+        serialized_message = await publisher._serialize_message(
+            "some_text_string"
+        )
         deserialized_message = serialized_message.decode()
         assert message == deserialized_message
 
@@ -233,7 +254,7 @@ class TestPublisherSerialization:
         assert message == deserialized_message
 
     @pytest.mark.asyncio
-    async def test_serialize_dictionary_with_unserializable_data_raises_exception(
+    async def test_unserializable_data_raises_exception(
         self, publisher: Publisher
     ):
         message = {"time": datetime.now()}
@@ -247,6 +268,8 @@ class TestPublisherSerialization:
         assert message == serialized_message
 
     @pytest.mark.asyncio
-    async def test_serialize_invalid_type_raises_exception(self, publisher: Publisher):
+    async def test_serialize_invalid_type_raises_exception(
+        self, publisher: Publisher
+    ):
         with pytest.raises(FastPubSubException):
             await publisher._serialize_message(2112)

--- a/tests/unit/test_pubsub_client_factory.py
+++ b/tests/unit/test_pubsub_client_factory.py
@@ -21,34 +21,53 @@ class TestPubSubClientFactory:
     @pytest.mark.asyncio
     async def test_get_publisher_caches_by_project_and_ordering(self):
         """Test that publishers are cached by (project_id, enable_ordering)."""
-        with patch("fastpubsub.clients.factory.PublisherClient") as mock_publisher_class:
+        with patch(
+            "fastpubsub.clients.factory.PublisherClient"
+        ) as mock_publisher_class:
             mock_publisher = MagicMock()
             mock_publisher_class.return_value = mock_publisher
 
             # First call should create a new client
-            client1 = await PubSubClientFactory.get_publisher("test-project", enable_ordering=False)
+            client1 = await PubSubClientFactory.get_publisher(
+                "test-project", enable_ordering=False
+            )
             assert client1 == mock_publisher
             assert mock_publisher_class.call_count == 1
 
             # Second call with same parameters should return cached client
-            client2 = await PubSubClientFactory.get_publisher("test-project", enable_ordering=False)
+            client2 = await PubSubClientFactory.get_publisher(
+                "test-project", enable_ordering=False
+            )
             assert client2 == mock_publisher
-            assert mock_publisher_class.call_count == 1  # No new client created
+            assert (
+                mock_publisher_class.call_count == 1
+            )  # No new client created
 
     @pytest.mark.asyncio
-    async def test_get_publisher_different_ordering_creates_separate_clients(self):
+    async def test_get_publisher_different_ordering_creates_separate_clients(
+        self,
+    ):
         """Test that different ordering flags create separate clients."""
-        with patch("fastpubsub.clients.factory.PublisherClient") as mock_publisher_class:
+        with patch(
+            "fastpubsub.clients.factory.PublisherClient"
+        ) as mock_publisher_class:
             mock_publisher1 = MagicMock()
             mock_publisher2 = MagicMock()
-            mock_publisher_class.side_effect = [mock_publisher1, mock_publisher2]
+            mock_publisher_class.side_effect = [
+                mock_publisher1,
+                mock_publisher2,
+            ]
 
             # Create client with ordering disabled
-            client1 = await PubSubClientFactory.get_publisher("test-project", enable_ordering=False)
+            client1 = await PubSubClientFactory.get_publisher(
+                "test-project", enable_ordering=False
+            )
             assert client1 == mock_publisher1
 
             # Create client with ordering enabled (should be different)
-            client2 = await PubSubClientFactory.get_publisher("test-project", enable_ordering=True)
+            client2 = await PubSubClientFactory.get_publisher(
+                "test-project", enable_ordering=True
+            )
             assert client2 == mock_publisher2
 
             # Verify two separate clients were created
@@ -58,7 +77,9 @@ class TestPubSubClientFactory:
     @pytest.mark.asyncio
     async def test_get_subscriber_caches_by_project(self):
         """Test that subscribers are cached by project_id."""
-        with patch("fastpubsub.clients.factory.SubscriberClient") as mock_subscriber_class:
+        with patch(
+            "fastpubsub.clients.factory.SubscriberClient"
+        ) as mock_subscriber_class:
             mock_subscriber = MagicMock()
             mock_subscriber_class.return_value = mock_subscriber
 
@@ -70,12 +91,16 @@ class TestPubSubClientFactory:
             # Second call with same project should return cached client
             client2 = await PubSubClientFactory.get_subscriber("test-project")
             assert client2 == mock_subscriber
-            assert mock_subscriber_class.call_count == 1  # No new client created
+            assert (
+                mock_subscriber_class.call_count == 1
+            )  # No new client created
 
     @pytest.mark.asyncio
     async def test_get_subscriber_same_project_returns_cached(self):
         """Test that same project_id returns cached subscriber."""
-        with patch("fastpubsub.clients.factory.SubscriberClient") as mock_subscriber_class:
+        with patch(
+            "fastpubsub.clients.factory.SubscriberClient"
+        ) as mock_subscriber_class:
             mock_subscriber = MagicMock()
             mock_subscriber_class.return_value = mock_subscriber
 
@@ -93,31 +118,42 @@ class TestPubSubClientFactory:
 
     @pytest.mark.asyncio
     async def test_concurrent_access_creates_single_client(self):
-        """Test that concurrent calls create only one client (async locking)."""
-        with patch("fastpubsub.clients.factory.PublisherClient") as mock_publisher_class:
+        with patch(
+            "fastpubsub.clients.factory.PublisherClient"
+        ) as mock_publisher_class:
             mock_publisher = MagicMock()
             mock_publisher_class.return_value = mock_publisher
 
             # Simulate concurrent access with asyncio.gather
             clients = await asyncio.gather(
-                PubSubClientFactory.get_publisher("test-project", enable_ordering=False),
-                PubSubClientFactory.get_publisher("test-project", enable_ordering=False),
-                PubSubClientFactory.get_publisher("test-project", enable_ordering=False),
-                PubSubClientFactory.get_publisher("test-project", enable_ordering=False),
+                PubSubClientFactory.get_publisher(
+                    "test-project", enable_ordering=False
+                ),
+                PubSubClientFactory.get_publisher(
+                    "test-project", enable_ordering=False
+                ),
+                PubSubClientFactory.get_publisher(
+                    "test-project", enable_ordering=False
+                ),
+                PubSubClientFactory.get_publisher(
+                    "test-project", enable_ordering=False
+                ),
             )
 
             # All should return the same instance
             assert all(client == mock_publisher for client in clients)
-
-            # Only one client should have been created despite concurrent access
             assert mock_publisher_class.call_count == 1
 
     @pytest.mark.asyncio
     async def test_close_all_closes_all_cached_clients(self):
         """Test that close_all closes all publishers and subscribers."""
         with (
-            patch("fastpubsub.clients.factory.PublisherClient") as mock_publisher_class,
-            patch("fastpubsub.clients.factory.SubscriberClient") as mock_subscriber_class,
+            patch(
+                "fastpubsub.clients.factory.PublisherClient"
+            ) as mock_publisher_class,
+            patch(
+                "fastpubsub.clients.factory.SubscriberClient"
+            ) as mock_subscriber_class,
         ):
             # Create mock clients with transport
             mock_publisher = MagicMock()
@@ -129,8 +165,12 @@ class TestPubSubClientFactory:
             mock_subscriber_class.return_value = mock_subscriber
 
             # Create some cached clients
-            await PubSubClientFactory.get_publisher("project-1", enable_ordering=False)
-            await PubSubClientFactory.get_publisher("project-1", enable_ordering=True)
+            await PubSubClientFactory.get_publisher(
+                "project-1", enable_ordering=False
+            )
+            await PubSubClientFactory.get_publisher(
+                "project-1", enable_ordering=True
+            )
             await PubSubClientFactory.get_subscriber("project-1")
 
             # Close all clients
@@ -145,8 +185,12 @@ class TestPubSubClientFactory:
     async def test_close_all_clears_cache(self):
         """Test that close_all clears the cache after closing."""
         with (
-            patch("fastpubsub.clients.factory.PublisherClient") as mock_publisher_class,
-            patch("fastpubsub.clients.factory.SubscriberClient") as mock_subscriber_class,
+            patch(
+                "fastpubsub.clients.factory.PublisherClient"
+            ) as mock_publisher_class,
+            patch(
+                "fastpubsub.clients.factory.SubscriberClient"
+            ) as mock_subscriber_class,
         ):
             mock_publisher = MagicMock()
             mock_publisher.transport.close = MagicMock()
@@ -157,7 +201,9 @@ class TestPubSubClientFactory:
             mock_subscriber_class.return_value = mock_subscriber
 
             # Create cached clients
-            await PubSubClientFactory.get_publisher("project-1", enable_ordering=False)
+            await PubSubClientFactory.get_publisher(
+                "project-1", enable_ordering=False
+            )
             await PubSubClientFactory.get_subscriber("project-1")
 
             # Verify cache has clients
@@ -175,12 +221,18 @@ class TestPubSubClientFactory:
     async def test_close_all_handles_exceptions_gracefully(self):
         """Test that close_all continues on client close errors."""
         with (
-            patch("fastpubsub.clients.factory.PublisherClient") as mock_publisher_class,
-            patch("fastpubsub.clients.factory.SubscriberClient") as mock_subscriber_class,
+            patch(
+                "fastpubsub.clients.factory.PublisherClient"
+            ) as mock_publisher_class,
+            patch(
+                "fastpubsub.clients.factory.SubscriberClient"
+            ) as mock_subscriber_class,
         ):
             # Create mock clients where transport.close raises exception
             mock_publisher = MagicMock()
-            mock_publisher.transport.close.side_effect = Exception("Transport error")
+            mock_publisher.transport.close.side_effect = Exception(
+                "Transport error"
+            )
             mock_publisher_class.return_value = mock_publisher
 
             mock_subscriber = MagicMock()
@@ -188,7 +240,9 @@ class TestPubSubClientFactory:
             mock_subscriber_class.return_value = mock_subscriber
 
             # Create cached clients
-            await PubSubClientFactory.get_publisher("project-1", enable_ordering=False)
+            await PubSubClientFactory.get_publisher(
+                "project-1", enable_ordering=False
+            )
             await PubSubClientFactory.get_subscriber("project-1")
 
             # close_all should not raise exception
@@ -200,19 +254,18 @@ class TestPubSubClientFactory:
 
     def test_clear_cache_without_closing(self):
         """Test that clear_cache clears without closing connections."""
-        with patch("fastpubsub.clients.factory.PublisherClient") as mock_publisher_class:
+        with patch(
+            "fastpubsub.clients.factory.PublisherClient"
+        ) as mock_publisher_class:
             mock_publisher = MagicMock()
             mock_publisher.transport.close = MagicMock()
             mock_publisher_class.return_value = mock_publisher
 
-            # Manually add to cache (simulating cached state)
-            PubSubClientFactory._publisher_cache[("project-1", False)] = mock_publisher
+            PubSubClientFactory._publisher_cache[("project-1", False)] = (
+                mock_publisher
+            )
 
-            # Clear cache
             PubSubClientFactory.clear_cache()
 
-            # Verify cache is empty
             assert len(PubSubClientFactory._publisher_cache) == 0
-
-            # Verify transport.close was NOT called (clear_cache doesn't close connections)
             mock_publisher.transport.close.assert_not_called()

--- a/tests/unit/test_pubsub_clients.py
+++ b/tests/unit/test_pubsub_clients.py
@@ -28,7 +28,9 @@ def subscriber():
         func=dummy_handler,
         topic_name="test-topic",
         subscription_name="test-subscription",
-        retry_policy=MessageRetryPolicy(min_backoff_delay_secs=10, max_backoff_delay_secs=60),
+        retry_policy=MessageRetryPolicy(
+            min_backoff_delay_secs=10, max_backoff_delay_secs=60
+        ),
         lifecycle_policy=LifecyclePolicy(autocreate=True, autoupdate=False),
         delivery_policy=MessageDeliveryPolicy(
             filter_expression="",
@@ -37,7 +39,9 @@ def subscriber():
             enable_exactly_once_delivery=False,
         ),
         control_flow_policy=MessageControlFlowPolicy(max_messages=1),
-        dead_letter_policy=DeadLetterPolicy(topic_name="dlt", max_delivery_attempts=5),
+        dead_letter_policy=DeadLetterPolicy(
+            topic_name="dlt", max_delivery_attempts=5
+        ),
     )
     subscriber._set_project_id("test-project")
     subscriber._build_callstack = MagicMock()
@@ -62,7 +66,9 @@ class TestPubSubClient:
     @pytest.fixture
     def sub_client(self) -> Generator[MagicMock]:
         mock_subscriber = MagicMock()
-        mock_subscriber.subscription_path = MagicMock(return_value="some_sub_path")
+        mock_subscriber.subscription_path = MagicMock(
+            return_value="some_sub_path"
+        )
         mock_subscriber.topic_path = MagicMock(return_value="some_topic_path")
         mock_subscriber.create_subscription = MagicMock()
         mock_subscriber.update_subscription = MagicMock()
@@ -75,7 +81,9 @@ class TestPubSubClient:
             yield mock_subscriber
 
     @pytest.mark.asyncio
-    async def test_create_topic(self, pub_client: MagicMock, sub_client: MagicMock):
+    async def test_create_topic(
+        self, pub_client: MagicMock, sub_client: MagicMock
+    ):
         client = PubSubClient(project_id="test-project")
         await client.create_topic("test-topic")
 
@@ -83,7 +91,9 @@ class TestPubSubClient:
         sub_client.create_subscription.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_topic_no_default_sub(self, pub_client: MagicMock, sub_client: MagicMock):
+    async def test_create_topic_no_default_sub(
+        self, pub_client: MagicMock, sub_client: MagicMock
+    ):
         client = PubSubClient(project_id="test-project")
         await client.create_topic("test-topic", False)
 
@@ -98,15 +108,22 @@ class TestPubSubClient:
         data = b"some_data"
 
         client = PubSubClient(project_id=project_id)
-        await client.publish(topic_name, data=data, ordering_key="", attributes=None)
+        await client.publish(
+            topic_name, data=data, ordering_key="", attributes=None
+        )
 
         pub_client.topic_path.assert_called_once_with(project_id, topic_name)
         pub_client.publish.assert_called_once_with(
-            topic=topic_path, data=data, ordering_key="", timeout=DEFAULT_PUSH_TIMEOUT
+            topic=topic_path,
+            data=data,
+            ordering_key="",
+            timeout=DEFAULT_PUSH_TIMEOUT,
         )
 
     @pytest.mark.asyncio
-    async def test_publish_failure(self, pub_client: MagicMock, sub_client: MagicMock):
+    async def test_publish_failure(
+        self, pub_client: MagicMock, sub_client: MagicMock
+    ):
         result = Future()
         result.set_exception(ValueError)
         pub_client.publish.return_value = result
@@ -114,11 +131,16 @@ class TestPubSubClient:
         client = PubSubClient(project_id="test-project")
         with pytest.raises(ValueError):
             await client.publish(
-                "test-topic", data=b"test-data", ordering_key=None, attributes=None
+                "test-topic",
+                data=b"test-data",
+                ordering_key=None,
+                attributes=None,
             )
 
     @pytest.mark.asyncio
-    async def test_create_subscription(self, subscriber: Subscriber, sub_client: MagicMock):
+    async def test_create_subscription(
+        self, subscriber: Subscriber, sub_client: MagicMock
+    ):
         client = PubSubClient(project_id="test-project")
         await client.create_subscription(
             topic_name=subscriber.topic_name,
@@ -130,7 +152,9 @@ class TestPubSubClient:
         sub_client.create_subscription.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_update_subscription(self, subscriber: Subscriber, sub_client: MagicMock):
+    async def test_update_subscription(
+        self, subscriber: Subscriber, sub_client: MagicMock
+    ):
         client = PubSubClient(project_id="test-project")
         client.is_emulator = False
         await client.update_subscription(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -16,7 +16,9 @@ class TestPubSubRouter:
     def test_realias_subscribers(self):
         router = PubSubRouter(prefix="api")
 
-        @router.subscriber(alias="test.alias", topic_name="topic", subscription_name="sub")
+        @router.subscriber(
+            alias="test.alias", topic_name="topic", subscription_name="sub"
+        )
         async def handler(msg):
             pass
 
@@ -39,11 +41,15 @@ class TestPubSubRouter:
     def test_get_subscribers(self):
         router = PubSubRouter()
 
-        @router.subscriber(alias="sub1", topic_name="topic1", subscription_name="sub1")
+        @router.subscriber(
+            alias="sub1", topic_name="topic1", subscription_name="sub1"
+        )
         async def handler1(msg):
             pass
 
-        @router.subscriber(alias="sub2", topic_name="topic2", subscription_name="sub2")
+        @router.subscriber(
+            alias="sub2", topic_name="topic2", subscription_name="sub2"
+        )
         async def handler2(msg):
             pass
 
@@ -59,11 +65,15 @@ class TestPubSubRouter:
         router.include_router(sub_router1)
         router.include_router(sub_router2)
 
-        @sub_router1.subscriber(alias="sub1", topic_name="topic1", subscription_name="sub1")
+        @sub_router1.subscriber(
+            alias="sub1", topic_name="topic1", subscription_name="sub1"
+        )
         async def handler1(msg):
             pass
 
-        @sub_router2.subscriber(alias="sub1", topic_name="topic2", subscription_name="sub2")
+        @sub_router2.subscriber(
+            alias="sub1", topic_name="topic2", subscription_name="sub2"
+        )
         async def handler2(msg):
             pass
 
@@ -77,11 +87,15 @@ class TestPubSubRouter:
         router.include_router(sub_router1)
         router.include_router(sub_router2)
 
-        @sub_router1.subscriber(alias="alias_a", topic_name="topic1", subscription_name="sub1")
+        @sub_router1.subscriber(
+            alias="alias_a", topic_name="topic1", subscription_name="sub1"
+        )
         async def handler1(msg):
             pass
 
-        @sub_router2.subscriber(alias="alias_b", topic_name="topic2", subscription_name="sub2")
+        @sub_router2.subscriber(
+            alias="alias_b", topic_name="topic2", subscription_name="sub2"
+        )
         async def handler2(msg):
             pass
 
@@ -112,14 +126,19 @@ class TestPubSubRouter:
     def test_nested_router_subscriber_retrieval(self):
         level2_router = PubSubRouter(prefix="level2")
 
-        @level2_router.subscriber(alias="alias", topic_name="topic", subscription_name="sub")
+        @level2_router.subscriber(
+            alias="alias", topic_name="topic", subscription_name="sub"
+        )
         async def handler(msg):
             pass
 
         level1_router = PubSubRouter(prefix="level1", routers=(level2_router,))
         subscribers = level1_router._get_subscribers()
         assert "level1.level2.alias" in subscribers
-        assert subscribers["level1.level2.alias"].subscription_name == "level1.level2.sub"
+        assert (
+            subscribers["level1.level2.alias"].subscription_name
+            == "level1.level2.sub"
+        )
 
     def test_error_on_basic_cyclical_router(self):
         router = PubSubRouter(prefix="")

--- a/tests/unit/test_streaming_pull_task.py
+++ b/tests/unit/test_streaming_pull_task.py
@@ -5,7 +5,10 @@ from concurrent.futures import Future
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from google.cloud.pubsub_v1.subscriber.exceptions import AcknowledgeError, AcknowledgeStatus
+from google.cloud.pubsub_v1.subscriber.exceptions import (
+    AcknowledgeError,
+    AcknowledgeStatus,
+)
 from google.cloud.pubsub_v1.subscriber.futures import StreamingPullFuture
 
 from fastpubsub.concurrency.tasks import MessageMapper, PubSubStreamingPullTask
@@ -48,7 +51,6 @@ class TestMessageMapper:
     def test_message_mapper_convert(
         self, mock_subscriber: MagicMock, mock_pubsub_message: MagicMock
     ):
-        """Test MessageMapper.convert() correctly maps PubSubMessage to Message."""
         mapper = MessageMapper(mock_subscriber)
 
         result = mapper.convert(mock_pubsub_message)
@@ -80,7 +82,9 @@ class TestPubSubStreamingPullTask:
 
     @pytest.fixture(autouse=True)
     def mock_get_loop(self):
-        with patch("fastpubsub.concurrency.tasks.asyncio.get_running_loop") as get_loop:
+        with patch(
+            "fastpubsub.concurrency.tasks.asyncio.get_running_loop"
+        ) as get_loop:
             yield get_loop
 
     @pytest.fixture
@@ -129,10 +133,11 @@ class TestPubSubStreamingPullTask:
 
     @pytest.mark.asyncio
     async def test_on_message_creates_task(
-        self, mock_get_loop: MagicMock, mock_subscriber: MagicMock, mock_pubsub_message: MagicMock
+        self,
+        mock_get_loop: MagicMock,
+        mock_subscriber: MagicMock,
+        mock_pubsub_message: MagicMock,
     ):
-        """Test that _on_message creates a task and registers it with scheduler."""
-
         event_loop = asyncio.get_event_loop()
         mock_get_loop.return_value = event_loop
 
@@ -222,7 +227,9 @@ class TestPubSubStreamingPullTask:
         task = PubSubStreamingPullTask(mock_subscriber)
 
         mock_callstack = MagicMock()
-        mock_callstack.on_message = AsyncMock(side_effect=ValueError("Test error"))
+        mock_callstack.on_message = AsyncMock(
+            side_effect=ValueError("Test error")
+        )
         mock_subscriber._build_callstack.return_value = mock_callstack
 
         nack_future = Future()
@@ -255,7 +262,9 @@ class TestPubSubStreamingPullTask:
         task = PubSubStreamingPullTask(mock_subscriber)
 
         future = Future()
-        error = AcknowledgeError(AcknowledgeStatus.PERMISSION_DENIED, "Permission denied")
+        error = AcknowledgeError(
+            AcknowledgeStatus.PERMISSION_DENIED, "Permission denied"
+        )
         future.set_exception(error)
 
         await task._wait_acknowledge_response(future)
@@ -269,7 +278,9 @@ class TestPubSubStreamingPullTask:
         task = PubSubStreamingPullTask(mock_subscriber)
 
         future = Future()
-        error = AcknowledgeError(AcknowledgeStatus.FAILED_PRECONDITION, "Failed precondition")
+        error = AcknowledgeError(
+            AcknowledgeStatus.FAILED_PRECONDITION, "Failed precondition"
+        )
         future.set_exception(error)
 
         await task._wait_acknowledge_response(future)
@@ -283,7 +294,9 @@ class TestPubSubStreamingPullTask:
         task = PubSubStreamingPullTask(mock_subscriber)
 
         future = Future()
-        error = AcknowledgeError(AcknowledgeStatus.INVALID_ACK_ID, "Invalid ack ID")
+        error = AcknowledgeError(
+            AcknowledgeStatus.INVALID_ACK_ID, "Invalid ack ID"
+        )
         future.set_exception(error)
 
         await task._wait_acknowledge_response(future)
@@ -305,8 +318,6 @@ class TestPubSubStreamingPullTask:
     async def test_shutdown_waits_and_cancels_task(
         self, mock_subscriber: MagicMock, mock_streaming_pull_future: MagicMock
     ):
-        """Test shutdown calls scheduler.wait_for_completion() then cancels StreamingPullFuture."""
-
         task = PubSubStreamingPullTask(mock_subscriber)
         task.task = mock_streaming_pull_future
         task.scheduler.wait_for_completion = AsyncMock(return_value=True)
@@ -314,6 +325,8 @@ class TestPubSubStreamingPullTask:
 
         await task.shutdown(timeout=30.0)
 
-        task.scheduler.wait_for_completion.assert_called_once_with(timeout=30.0)
+        task.scheduler.wait_for_completion.assert_called_once_with(
+            timeout=30.0
+        )
         mock_streaming_pull_future.cancel.assert_called_once()
         mock_streaming_pull_future.result.assert_called_once_with(timeout=30.0)

--- a/tests/unit/test_subscriber.py
+++ b/tests/unit/test_subscriber.py
@@ -13,7 +13,11 @@ from tests.conftest import callstack_matches, callstack_to_collection
 
 
 def subscriber_create_test_cases():
-    default_parameters = {"alias": "alias", "topic_name": "topic", "subscription_name": "sub"}
+    default_parameters = {
+        "alias": "alias",
+        "topic_name": "topic",
+        "subscription_name": "sub",
+    }
 
     class InvalidMiddlewareClass: ...
 
@@ -41,9 +45,17 @@ def subscriber_create_test_cases():
         [{**default_parameters, "max_backoff_delay_secs": None}],
         [{**default_parameters, "max_messages": None}],
         [{**default_parameters, "middlewares": True}],
-        [{**default_parameters, "middlewares": Middleware(InvalidMiddlewareClass)}],
         [
-            {**default_parameters, "middlewares": Middleware(ValidMiddlewareWithParameter, True)}
+            {
+                **default_parameters,
+                "middlewares": Middleware(InvalidMiddlewareClass),
+            }
+        ],
+        [
+            {
+                **default_parameters,
+                "middlewares": Middleware(ValidMiddlewareWithParameter, True),
+            }
         ],  # Invalid type
     ]
 
@@ -53,9 +65,9 @@ def subscriber(broker: PubSubBroker) -> Subscriber:
     async def some_subscriber_handler():
         pass
 
-    broker.subscriber("some_sub", topic_name="some_topic", subscription_name="some_sub_name")(
-        some_subscriber_handler
-    )
+    broker.subscriber(
+        "some_sub", topic_name="some_topic", subscription_name="some_sub_name"
+    )(some_subscriber_handler)
     subscribers = broker.router._get_subscribers()
     return subscribers.popitem()[1]
 
@@ -78,9 +90,15 @@ class TestSubscriber:
         async def handler_b(_): ...
         async def handler_broker(_): ...
 
-        router_a.subscriber("sub_a", topic_name="tn", subscription_name="sn")(handler_a)
-        router_b.subscriber("sub_b", topic_name="tn", subscription_name="sn")(handler_b)
-        broker.subscriber("sub_c", topic_name="tn", subscription_name="sn")(handler_broker)
+        router_a.subscriber("sub_a", topic_name="tn", subscription_name="sn")(
+            handler_a
+        )
+        router_b.subscriber("sub_b", topic_name="tn", subscription_name="sn")(
+            handler_b
+        )
+        broker.subscriber("sub_c", topic_name="tn", subscription_name="sn")(
+            handler_broker
+        )
         subscribers = broker.router._get_subscribers()
 
         subscriber_a = subscribers["a.sub_a"]
@@ -90,7 +108,11 @@ class TestSubscriber:
 
         subscriber_b = subscribers["a.b.sub_b"]
         callstack_b = subscriber_b._build_callstack()
-        expected_output = [second_middleware, first_middleware, HandleMessageSerializerMiddleware]
+        expected_output = [
+            second_middleware,
+            first_middleware,
+            HandleMessageSerializerMiddleware,
+        ]
         assert callstack_matches(callstack_b, expected_output)
 
         subscriber_c = subscribers["sub_c"]
@@ -105,19 +127,29 @@ class TestSubscriber:
         first_middleware: type[BaseMiddleware],
         second_middleware: type[BaseMiddleware],
     ):
-        broker.include_middleware(first_middleware, "broker_arg", arg_2="broker_kwarg")
-        broker.include_middleware(second_middleware, arg_2="broker_kwargs_only")
-        router_a.include_middleware(first_middleware, "router_arg", arg_2="router_kwarg")
+        broker.include_middleware(
+            first_middleware, "broker_arg", arg_2="broker_kwarg"
+        )
+        broker.include_middleware(
+            second_middleware, arg_2="broker_kwargs_only"
+        )
+        router_a.include_middleware(
+            first_middleware, "router_arg", arg_2="router_kwarg"
+        )
         router_a.include_middleware(second_middleware, "router_arg_only")
         broker.include_router(router_a)
 
         async def handler_a(_): ...
 
-        broker.subscriber("broker_handler", topic_name="tn", subscription_name="sn")(handler_a)
+        broker.subscriber(
+            "broker_handler", topic_name="tn", subscription_name="sn"
+        )(handler_a)
 
         async def handler_b(_): ...
 
-        router_a.subscriber("router_handler", topic_name="tn", subscription_name="sn")(handler_b)
+        router_a.subscriber(
+            "router_handler", topic_name="tn", subscription_name="sn"
+        )(handler_b)
 
         subscribers = broker.router._get_subscribers()
 
@@ -167,15 +199,21 @@ class TestSubscriber:
         ]
 
         router = PubSubRouter(middlewares=router_middlewares)
-        broker = PubSubBroker("some_project", routers=[router], middlewares=broker_middlewares)
+        broker = PubSubBroker(
+            "some_project", routers=[router], middlewares=broker_middlewares
+        )
 
         async def handler_a(_): ...
 
-        broker.subscriber("sub_a", topic_name="tn", subscription_name="sn")(handler_a)
+        broker.subscriber("sub_a", topic_name="tn", subscription_name="sn")(
+            handler_a
+        )
 
         async def handler_b(_): ...
 
-        router.subscriber("sub_b", topic_name="tn", subscription_name="sn")(handler_b)
+        router.subscriber("sub_b", topic_name="tn", subscription_name="sn")(
+            handler_b
+        )
 
         subscribers = broker.router._get_subscribers()
 
@@ -238,7 +276,10 @@ class TestSubscriber:
         subscriber_create_test_cases(),
     )
     def test_subscriber_invalid_data_failed(
-        self, data: dict[str, Any], broker: PubSubBroker, router_a: PubSubRouter
+        self,
+        data: dict[str, Any],
+        broker: PubSubBroker,
+        router_a: PubSubRouter,
     ):
         objs = [broker, router_a]
         for obj in objs:

--- a/tests/unit/test_subscription_builder.py
+++ b/tests/unit/test_subscription_builder.py
@@ -20,7 +20,9 @@ BUILDER_MODULE_PATH = "fastpubsub.builder"
 class TestSubscriptionBuilder:
     @pytest.fixture
     def subscriber(self):
-        dead_letter_policy = DeadLetterPolicy(topic_name="dlt_topic", max_delivery_attempts=5)
+        dead_letter_policy = DeadLetterPolicy(
+            topic_name="dlt_topic", max_delivery_attempts=5
+        )
 
         retry_policy = MessageRetryPolicy(
             min_backoff_delay_secs=10,
@@ -68,11 +70,16 @@ class TestSubscriptionBuilder:
     async def test_build_full_subscription_successfully(
         self, pubsub_client: MagicMock, subscriber: Subscriber
     ):
-        subscription_builder = PubSubSubscriptionBuilder(project_id=subscriber.project_id)
+        subscription_builder = PubSubSubscriptionBuilder(
+            project_id=subscriber.project_id
+        )
         await subscription_builder.build(subscriber=subscriber)
 
         expected_calls = [
-            call.create_topic(topic_name=subscriber.topic_name, create_default_subscription=False),
+            call.create_topic(
+                topic_name=subscriber.topic_name,
+                create_default_subscription=False,
+            ),
             call.create_topic(
                 topic_name=subscriber.dead_letter_policy.topic_name,
                 create_default_subscription=True,
@@ -99,13 +106,18 @@ class TestSubscriptionBuilder:
     async def test_build_subscription_no_autoupdate(
         self, pubsub_client: MagicMock, subscriber: Subscriber
     ):
-        subscriber.lifecycle_policy = LifecyclePolicy(autocreate=True, autoupdate=False)
-        subscription_builder = PubSubSubscriptionBuilder(project_id=subscriber.project_id)
+        subscriber.lifecycle_policy = LifecyclePolicy(
+            autocreate=True, autoupdate=False
+        )
+        subscription_builder = PubSubSubscriptionBuilder(
+            project_id=subscriber.project_id
+        )
         await subscription_builder.build(subscriber=subscriber)
 
         assert pubsub_client.create_topic.call_count == 2
         pubsub_client.create_topic.assert_called_with(
-            topic_name=subscriber.dead_letter_policy.topic_name, create_default_subscription=True
+            topic_name=subscriber.dead_letter_policy.topic_name,
+            create_default_subscription=True,
         )
 
         pubsub_client.create_subscription.assert_called_once_with(
@@ -122,8 +134,12 @@ class TestSubscriptionBuilder:
     async def test_build_subscription_no_autocreate(
         self, pubsub_client: MagicMock, subscriber: Subscriber
     ):
-        subscriber.lifecycle_policy = LifecyclePolicy(autocreate=False, autoupdate=True)
-        subscription_builder = PubSubSubscriptionBuilder(project_id=subscriber.project_id)
+        subscriber.lifecycle_policy = LifecyclePolicy(
+            autocreate=False, autoupdate=True
+        )
+        subscription_builder = PubSubSubscriptionBuilder(
+            project_id=subscriber.project_id
+        )
         await subscription_builder.build(subscriber=subscriber)
 
         pubsub_client.create_topic.assert_not_called()
@@ -141,7 +157,9 @@ class TestSubscriptionBuilder:
         self, pubsub_client: MagicMock, subscriber: Subscriber
     ):
         subscriber.dead_letter_policy = None
-        subscription_builder = PubSubSubscriptionBuilder(project_id=subscriber.project_id)
+        subscription_builder = PubSubSubscriptionBuilder(
+            project_id=subscriber.project_id
+        )
         await subscription_builder.build(subscriber=subscriber)
 
         pubsub_client.create_topic.assert_called_once_with(
@@ -165,14 +183,19 @@ class TestSubscriptionBuilder:
         )
 
     @pytest.mark.asyncio
-    async def test_topic_only_created_once(self, pubsub_client: MagicMock, subscriber: Subscriber):
-        subscription_builder = PubSubSubscriptionBuilder(project_id=subscriber.project_id)
+    async def test_topic_only_created_once(
+        self, pubsub_client: MagicMock, subscriber: Subscriber
+    ):
+        subscription_builder = PubSubSubscriptionBuilder(
+            project_id=subscriber.project_id
+        )
         subscriber_one = deepcopy(subscriber)
         await subscription_builder.build(subscriber=subscriber_one)
 
         expected_calls = [
             call.create_topic(
-                topic_name=subscriber_one.topic_name, create_default_subscription=False
+                topic_name=subscriber_one.topic_name,
+                create_default_subscription=False,
             ),
             call.create_topic(
                 topic_name=subscriber_one.dead_letter_policy.topic_name,

--- a/tests/unit/test_task_manager.py
+++ b/tests/unit/test_task_manager.py
@@ -12,7 +12,9 @@ ASYNC_TASK_MANAGER_MODULE_PATH = "fastpubsub.concurrency.manager"
 class TestAsyncTaskManager:
     @pytest.fixture()
     def task(self) -> Generator[MagicMock]:
-        with patch(f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubStreamingPullTask") as streaming_task:
+        with patch(
+            f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubStreamingPullTask"
+        ) as streaming_task:
             streaming_task.return_value.start = AsyncMock()
             streaming_task.return_value.shutdown = AsyncMock()
             yield streaming_task
@@ -89,16 +91,24 @@ class TestAsyncTaskManagerShutdown:
 
     @pytest.fixture()
     def task(self) -> Generator[MagicMock]:
-        with patch(f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubStreamingPullTask") as streaming_task:
+        with patch(
+            f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubStreamingPullTask"
+        ) as streaming_task:
             streaming_task.return_value.start = AsyncMock()
             streaming_task.return_value.shutdown = AsyncMock()
-            streaming_task.return_value.task_alive = MagicMock(return_value=True)
+            streaming_task.return_value.task_alive = MagicMock(
+                return_value=True
+            )
             yield streaming_task
 
     @pytest.mark.asyncio
-    async def test_shutdown_calls_task_shutdown_with_timeout(self, task: MagicMock):
+    async def test_shutdown_calls_task_shutdown_with_timeout(
+        self, task: MagicMock
+    ):
         """Test that shutdown calls each task's shutdown with timeout."""
-        with patch(f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory") as mock_factory:
+        with patch(
+            f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory"
+        ) as mock_factory:
             mock_factory.close_all = AsyncMock()
 
             task_manager = AsyncTaskManager()
@@ -114,7 +124,9 @@ class TestAsyncTaskManagerShutdown:
     @pytest.mark.asyncio
     async def test_shutdown_clears_tasks_list(self, task: MagicMock):
         """Test that shutdown clears the tasks list."""
-        with patch(f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory") as mock_factory:
+        with patch(
+            f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory"
+        ) as mock_factory:
             mock_factory.close_all = AsyncMock()
 
             task_manager = AsyncTaskManager()
@@ -132,7 +144,9 @@ class TestAsyncTaskManagerShutdown:
     @pytest.mark.asyncio
     async def test_shutdown_closes_factory_clients(self, task: MagicMock):
         """Test that shutdown calls PubSubClientFactory.close_all()."""
-        with patch(f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory") as mock_factory:
+        with patch(
+            f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory"
+        ) as mock_factory:
             mock_factory.close_all = AsyncMock()
 
             task_manager = AsyncTaskManager()
@@ -146,7 +160,9 @@ class TestAsyncTaskManagerShutdown:
     @pytest.mark.asyncio
     async def test_shutdown_skips_dead_tasks(self, task: MagicMock):
         """Test that shutdown only processes alive tasks."""
-        with patch(f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory") as mock_factory:
+        with patch(
+            f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory"
+        ) as mock_factory:
             mock_factory.close_all = AsyncMock()
 
             # Set task_alive to return False
@@ -163,7 +179,9 @@ class TestAsyncTaskManagerShutdown:
     @pytest.mark.asyncio
     async def test_shutdown_propagates_timeout_to_tasks(self, task: MagicMock):
         """Test that custom timeout is propagated."""
-        with patch(f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory") as mock_factory:
+        with patch(
+            f"{ASYNC_TASK_MANAGER_MODULE_PATH}.PubSubClientFactory"
+        ) as mock_factory:
             mock_factory.close_all = AsyncMock()
 
             task_manager = AsyncTaskManager()

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -31,12 +31,28 @@ class TestMatchesFilter:
         assert matches_filter({"key": "value"}, "\n\t") is True
 
     def test_exact_match_equals_double_quotes(self):
-        assert matches_filter({"event_type": "order"}, 'attributes.event_type = "order"') is True
-        assert matches_filter({"event_type": "user"}, 'attributes.event_type = "order"') is False
+        assert (
+            matches_filter(
+                {"event_type": "order"}, 'attributes.event_type = "order"'
+            )
+            is True
+        )
+        assert (
+            matches_filter(
+                {"event_type": "user"}, 'attributes.event_type = "order"'
+            )
+            is False
+        )
 
     def test_exact_match_equals_single_quotes(self):
-        assert matches_filter({"type": "test"}, "attributes.type = 'test'") is True
-        assert matches_filter({"type": "other"}, "attributes.type = 'test'") is False
+        assert (
+            matches_filter({"type": "test"}, "attributes.type = 'test'")
+            is True
+        )
+        assert (
+            matches_filter({"type": "other"}, "attributes.type = 'test'")
+            is False
+        )
 
     def test_exact_match_missing_attribute(self):
         assert matches_filter({}, 'attributes.event_type = "order"') is False
@@ -46,10 +62,16 @@ class TestMatchesFilter:
         assert matches_filter({"key": "value"}, 'attributes.key = ""') is False
 
     def test_not_equals_different_value(self):
-        assert matches_filter({"type": "user"}, 'attributes.type != "order"') is True
+        assert (
+            matches_filter({"type": "user"}, 'attributes.type != "order"')
+            is True
+        )
 
     def test_not_equals_same_value(self):
-        assert matches_filter({"type": "order"}, 'attributes.type != "order"') is False
+        assert (
+            matches_filter({"type": "order"}, 'attributes.type != "order"')
+            is False
+        )
 
     def test_not_equals_missing_attribute(self):
         assert matches_filter({}, 'attributes.type != "order"') is True
@@ -71,21 +93,37 @@ class TestMatchesFilter:
         assert matches_filter({"my_key": "value"}, "attributes:my_key") is True
 
     def test_has_prefix_match(self):
-        result = matches_filter({"region": "us-east-1"}, 'hasPrefix(attributes.region, "us-")')
+        result = matches_filter(
+            {"region": "us-east-1"}, 'hasPrefix(attributes.region, "us-")'
+        )
         assert result is True
 
     def test_has_prefix_no_match(self):
-        result = matches_filter({"region": "eu-west-1"}, 'hasPrefix(attributes.region, "us-")')
+        result = matches_filter(
+            {"region": "eu-west-1"}, 'hasPrefix(attributes.region, "us-")'
+        )
         assert result is False
 
     def test_has_prefix_missing_attribute(self):
-        assert matches_filter({}, 'hasPrefix(attributes.region, "us-")') is False
+        assert (
+            matches_filter({}, 'hasPrefix(attributes.region, "us-")') is False
+        )
 
     def test_has_prefix_empty_prefix(self):
-        assert matches_filter({"region": "us-east-1"}, 'hasPrefix(attributes.region, "")') is True
+        assert (
+            matches_filter(
+                {"region": "us-east-1"}, 'hasPrefix(attributes.region, "")'
+            )
+            is True
+        )
 
     def test_has_prefix_exact_match(self):
-        assert matches_filter({"region": "us"}, 'hasPrefix(attributes.region, "us")') is True
+        assert (
+            matches_filter(
+                {"region": "us"}, 'hasPrefix(attributes.region, "us")'
+            )
+            is True
+        )
 
     def test_and_both_true(self):
         attrs = {"type": "order", "status": "pending"}
@@ -109,7 +147,9 @@ class TestMatchesFilter:
 
     def test_multiple_and(self):
         attrs = {"a": "1", "b": "2", "c": "3"}
-        expr = 'attributes.a = "1" AND attributes.b = "2" AND attributes.c = "3"'
+        expr = (
+            'attributes.a = "1" AND attributes.b = "2" AND attributes.c = "3"'
+        )
         assert matches_filter(attrs, expr) is True
 
     def test_or_first_true(self):
@@ -134,33 +174,52 @@ class TestMatchesFilter:
 
     def test_multiple_or(self):
         attrs = {"type": "refund"}
-        expr = 'attributes.type = "order" OR attributes.type = "user" OR attributes.type = "refund"'
+        expr = (
+            'attributes.type = "order" OR '
+            'attributes.type = "user" OR '
+            'attributes.type = "refund"'
+        )
         assert matches_filter(attrs, expr) is True
 
     def test_not_operator_false_becomes_true(self):
-        assert matches_filter({"type": "user"}, 'NOT attributes.type = "order"') is True
+        assert (
+            matches_filter({"type": "user"}, 'NOT attributes.type = "order"')
+            is True
+        )
 
     def test_not_operator_true_becomes_false(self):
-        assert matches_filter({"type": "order"}, 'NOT attributes.type = "order"') is False
+        assert (
+            matches_filter({"type": "order"}, 'NOT attributes.type = "order"')
+            is False
+        )
 
     def test_not_with_existence(self):
         assert matches_filter({}, "NOT attributes:key") is True
         assert matches_filter({"key": "value"}, "NOT attributes:key") is False
 
     def test_double_not(self):
-        assert matches_filter({"type": "order"}, 'NOT NOT attributes.type = "order"') is True
+        assert (
+            matches_filter(
+                {"type": "order"}, 'NOT NOT attributes.type = "order"'
+            )
+            is True
+        )
 
     def test_and_has_higher_precedence_than_or(self):
         """Tests if 'a OR b AND c' means 'a OR (b AND c)'"""
         attrs = {"a": "1"}
-        expr = 'attributes.a = "1" OR attributes.b = "2" AND attributes.c = "3"'
+        expr = (
+            'attributes.a = "1" OR attributes.b = "2" AND attributes.c = "3"'
+        )
 
         # True OR (False AND False) -> True OR False -> True
         assert matches_filter(attrs, expr) is True
 
     def test_and_has_higher_precedence_than_or_second_case(self):
         attrs = {"b": "2", "c": "3"}
-        expr = 'attributes.a = "1" OR attributes.b = "2" AND attributes.c = "3"'
+        expr = (
+            'attributes.a = "1" OR attributes.b = "2" AND attributes.c = "3"'
+        )
         # False OR (True AND True) -> False OR True -> True
         assert matches_filter(attrs, expr) is True
 
@@ -168,7 +227,9 @@ class TestMatchesFilter:
         """Tests if parantheses change the precendence"""
 
         attrs = {"a": "1", "b": "2"}
-        expr = '(attributes.a = "1" OR attributes.b = "2") AND attributes.c = "3"'
+        expr = (
+            '(attributes.a = "1" OR attributes.b = "2") AND attributes.c = "3"'
+        )
         # (True OR True) AND False -> True AND False -> False
         assert matches_filter(attrs, expr) is False
 
@@ -267,7 +328,9 @@ class TestPubSubTestClient:
         assert len(client._patchers) == 0
 
     @pytest.mark.asyncio
-    async def test_context_manager_stops_patches_on_exception(self, broker: PubSubBroker):
+    async def test_context_manager_stops_patches_on_exception(
+        self, broker: PubSubBroker
+    ):
         client = PubSubTestClient(broker)
 
         with pytest.raises(RuntimeError):
@@ -292,7 +355,9 @@ class TestPubSubTestClient:
         received_messages: list[Message] = []
 
         @broker.subscriber(
-            alias="test-sub", topic_name="test-topic", subscription_name="test-subscription"
+            alias="test-sub",
+            topic_name="test-topic",
+            subscription_name="test-subscription",
         )
         async def handler(msg: Message) -> None:
             received_messages.append(msg)
@@ -304,18 +369,24 @@ class TestPubSubTestClient:
 
     # Publish with multiple subscribers (same topic)
     @pytest.mark.asyncio
-    async def test_publish_with_multiple_subscribers_same_topic(self, broker: PubSubBroker):
+    async def test_publish_with_multiple_subscribers_same_topic(
+        self, broker: PubSubBroker
+    ):
         received_a: list[Message] = []
         received_b: list[Message] = []
 
         @broker.subscriber(
-            alias="sub-a", topic_name="test-topic", subscription_name="subscription-a"
+            alias="sub-a",
+            topic_name="test-topic",
+            subscription_name="subscription-a",
         )
         async def handler_a(msg: Message) -> None:
             received_a.append(msg)
 
         @broker.subscriber(
-            alias="sub-b", topic_name="test-topic", subscription_name="subscription-b"
+            alias="sub-b",
+            topic_name="test-topic",
+            subscription_name="subscription-b",
         )
         async def handler_b(msg: Message) -> None:
             received_b.append(msg)
@@ -332,11 +403,19 @@ class TestPubSubTestClient:
         received_a: list[Message] = []
         received_b: list[Message] = []
 
-        @broker.subscriber(alias="sub-a", topic_name="topic-a", subscription_name="subscription-a")
+        @broker.subscriber(
+            alias="sub-a",
+            topic_name="topic-a",
+            subscription_name="subscription-a",
+        )
         async def handler_a(msg: Message) -> None:
             received_a.append(msg)
 
-        @broker.subscriber(alias="sub-b", topic_name="topic-b", subscription_name="subscription-b")
+        @broker.subscriber(
+            alias="sub-b",
+            topic_name="topic-b",
+            subscription_name="subscription-b",
+        )
         async def handler_b(msg: Message) -> None:
             received_b.append(msg)
 
@@ -363,41 +442,56 @@ class TestPubSubTestClient:
         async with PubSubTestClient(broker) as client:
             # Should be received
             await client.publish(
-                {"data": "order1"}, topic="events", attributes={"event_type": "order"}
+                {"data": "order1"},
+                topic="events",
+                attributes={"event_type": "order"},
             )
             # Should NOT be received
             await client.publish(
-                {"data": "user1"}, topic="events", attributes={"event_type": "user"}
+                {"data": "user1"},
+                topic="events",
+                attributes={"event_type": "user"},
             )
 
         assert len(received) == 1
         assert received[0].attributes["event_type"] == "order"
 
     @pytest.mark.asyncio
-    async def test_filter_expression_no_filter_receives_all(self, broker: PubSubBroker):
+    async def test_filter_expression_no_filter_receives_all(
+        self, broker: PubSubBroker
+    ):
         received: list[Message] = []
 
         @broker.subscriber(
-            alias="unfiltered-sub", topic_name="events", subscription_name="unfiltered-subscription"
+            alias="unfiltered-sub",
+            topic_name="events",
+            subscription_name="unfiltered-subscription",
         )
         async def handler(msg: Message) -> None:
             received.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("msg1", topic="events", attributes={"type": "a"})
-            await client.publish("msg2", topic="events", attributes={"type": "b"})
+            await client.publish(
+                "msg1", topic="events", attributes={"type": "a"}
+            )
+            await client.publish(
+                "msg2", topic="events", attributes={"type": "b"}
+            )
 
         assert len(received) == 2
 
     @pytest.mark.asyncio
     async def test_filter_expression_and_operator(self, broker: PubSubBroker):
         received: list[Message] = []
+        FILTER_EXPRESSION = (
+            'attributes.type = "order" AND attributes.status = "pending"'
+        )
 
         @broker.subscriber(
             alias="and-filter-sub",
             topic_name="events",
             subscription_name="and-filter-subscription",
-            filter_expression='attributes.type = "order" AND attributes.status = "pending"',
+            filter_expression=FILTER_EXPRESSION,
         )
         async def handler(msg: Message) -> None:
             received.append(msg)
@@ -405,11 +499,15 @@ class TestPubSubTestClient:
         async with PubSubTestClient(broker) as client:
             # Matches
             await client.publish(
-                "msg1", topic="events", attributes={"type": "order", "status": "pending"}
+                "msg1",
+                topic="events",
+                attributes={"type": "order", "status": "pending"},
             )
             # Doesn't match (wrong status)
             await client.publish(
-                "msg2", topic="events", attributes={"type": "order", "status": "completed"}
+                "msg2",
+                topic="events",
+                attributes={"type": "order", "status": "completed"},
             )
 
         assert len(received) == 1
@@ -417,20 +515,29 @@ class TestPubSubTestClient:
     @pytest.mark.asyncio
     async def test_filter_expression_or_operator(self, broker: PubSubBroker):
         received: list[Message] = []
+        FILTER_EXPRESSION = (
+            'attributes.type = "order" OR attributes.type = "refund"'
+        )
 
         @broker.subscriber(
             alias="or-filter-sub",
             topic_name="events",
             subscription_name="or-filter-subscription",
-            filter_expression='attributes.type = "order" OR attributes.type = "refund"',
+            filter_expression=FILTER_EXPRESSION,
         )
         async def handler(msg: Message) -> None:
             received.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("msg1", topic="events", attributes={"type": "order"})
-            await client.publish("msg2", topic="events", attributes={"type": "refund"})
-            await client.publish("msg3", topic="events", attributes={"type": "user"})
+            await client.publish(
+                "msg1", topic="events", attributes={"type": "order"}
+            )
+            await client.publish(
+                "msg2", topic="events", attributes={"type": "refund"}
+            )
+            await client.publish(
+                "msg3", topic="events", attributes={"type": "user"}
+            )
 
         assert len(received) == 2
 
@@ -448,14 +555,20 @@ class TestPubSubTestClient:
             received.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("msg1", topic="events", attributes={"type": "order"})
-            await client.publish("msg2", topic="events", attributes={"type": "test"})
+            await client.publish(
+                "msg1", topic="events", attributes={"type": "order"}
+            )
+            await client.publish(
+                "msg2", topic="events", attributes={"type": "test"}
+            )
 
         assert len(received) == 1
         assert received[0].attributes["type"] == "order"
 
     @pytest.mark.asyncio
-    async def test_filter_expression_existence_check(self, broker: PubSubBroker):
+    async def test_filter_expression_existence_check(
+        self, broker: PubSubBroker
+    ):
         received: list[Message] = []
 
         @broker.subscriber(
@@ -468,8 +581,12 @@ class TestPubSubTestClient:
             received.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("msg1", topic="events", attributes={"priority": "high"})
-            await client.publish("msg2", topic="events", attributes={"other": "value"})
+            await client.publish(
+                "msg1", topic="events", attributes={"priority": "high"}
+            )
+            await client.publish(
+                "msg2", topic="events", attributes={"other": "value"}
+            )
 
         assert len(received) == 1
 
@@ -487,8 +604,12 @@ class TestPubSubTestClient:
             received.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("msg1", topic="events", attributes={"region": "us-east-1"})
-            await client.publish("msg2", topic="events", attributes={"region": "eu-west-1"})
+            await client.publish(
+                "msg1", topic="events", attributes={"region": "us-east-1"}
+            )
+            await client.publish(
+                "msg2", topic="events", attributes={"region": "eu-west-1"}
+            )
 
         assert len(received) == 1
 
@@ -518,9 +639,15 @@ class TestPubSubTestClient:
             users.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("o1", topic="events", attributes={"type": "order"})
-            await client.publish("u1", topic="events", attributes={"type": "user"})
-            await client.publish("o2", topic="events", attributes={"type": "order"})
+            await client.publish(
+                "o1", topic="events", attributes={"type": "order"}
+            )
+            await client.publish(
+                "u1", topic="events", attributes={"type": "user"}
+            )
+            await client.publish(
+                "o2", topic="events", attributes={"type": "order"}
+            )
 
         assert len(orders) == 2
         assert len(users) == 1
@@ -529,8 +656,12 @@ class TestPubSubTestClient:
     @pytest.mark.asyncio
     async def test_get_published_messages(self, broker: PubSubBroker):
         async with PubSubTestClient(broker) as client:
-            await client.publish("msg1", topic="topic-a", attributes={"key": "1"})
-            await client.publish("msg2", topic="topic-b", attributes={"key": "2"})
+            await client.publish(
+                "msg1", topic="topic-a", attributes={"key": "1"}
+            )
+            await client.publish(
+                "msg2", topic="topic-b", attributes={"key": "2"}
+            )
 
             messages = client.get_published_messages()
             assert len(messages) == 2
@@ -538,7 +669,9 @@ class TestPubSubTestClient:
             assert messages[1].topic_name == "topic-b"
 
     @pytest.mark.asyncio
-    async def test_get_published_messages_returns_copy(self, broker: PubSubBroker):
+    async def test_get_published_messages_returns_copy(
+        self, broker: PubSubBroker
+    ):
         async with PubSubTestClient(broker) as client:
             await client.publish("msg", topic="topic")
 
@@ -562,7 +695,9 @@ class TestPubSubTestClient:
 
     # Middleware execution tests
     @pytest.mark.asyncio
-    async def test_middleware_execution_in_test_client(self, broker: PubSubBroker):
+    async def test_middleware_execution_in_test_client(
+        self, broker: PubSubBroker
+    ):
         middleware_calls: list[str] = []
 
         class TestMiddleware(BaseMiddleware):
@@ -586,11 +721,15 @@ class TestPubSubTestClient:
 
     # Message content tests
     @pytest.mark.asyncio
-    async def test_message_attributes_passed_correctly(self, broker: PubSubBroker):
+    async def test_message_attributes_passed_correctly(
+        self, broker: PubSubBroker
+    ):
         received_msg: Message | None = None
 
         @broker.subscriber(
-            alias="attr-sub", topic_name="test-topic", subscription_name="attr-subscription"
+            alias="attr-sub",
+            topic_name="test-topic",
+            subscription_name="attr-subscription",
         )
         async def handler(msg: Message) -> None:
             nonlocal received_msg
@@ -598,18 +737,24 @@ class TestPubSubTestClient:
 
         async with PubSubTestClient(broker) as client:
             await client.publish(
-                "test", topic="test-topic", attributes={"key1": "value1", "key2": "value2"}
+                "test",
+                topic="test-topic",
+                attributes={"key1": "value1", "key2": "value2"},
             )
 
         assert received_msg is not None
         assert received_msg.attributes == {"key1": "value1", "key2": "value2"}
 
     @pytest.mark.asyncio
-    async def test_message_topic_and_subscriber_name(self, broker: PubSubBroker):
+    async def test_message_topic_and_subscriber_name(
+        self, broker: PubSubBroker
+    ):
         received_msg: Message | None = None
 
         @broker.subscriber(
-            alias="meta-sub", topic_name="my-topic", subscription_name="my-subscription"
+            alias="meta-sub",
+            topic_name="my-topic",
+            subscription_name="my-subscription",
         )
         async def handler(msg: Message) -> None:
             nonlocal received_msg
@@ -627,7 +772,11 @@ class TestPubSubTestClient:
     async def test_message_has_unique_id(self, broker: PubSubBroker):
         received_msgs: list[Message] = []
 
-        @broker.subscriber(alias="id-sub", topic_name="topic", subscription_name="subscription")
+        @broker.subscriber(
+            alias="id-sub",
+            topic_name="topic",
+            subscription_name="subscription",
+        )
         async def handler(msg: Message) -> None:
             received_msgs.append(msg)
 
@@ -645,7 +794,9 @@ class TestPubSubTestClient:
         received_msg: Message | None = None
 
         @broker.subscriber(
-            alias="delivery-sub", topic_name="topic", subscription_name="subscription"
+            alias="delivery-sub",
+            topic_name="topic",
+            subscription_name="subscription",
         )
         async def handler(msg: Message) -> None:
             nonlocal received_msg
@@ -662,13 +813,19 @@ class TestPubSubTestClient:
     async def test_publish_dict_data(self, broker: PubSubBroker):
         received_msg: Message | None = None
 
-        @broker.subscriber(alias="dict-sub", topic_name="topic", subscription_name="subscription")
+        @broker.subscriber(
+            alias="dict-sub",
+            topic_name="topic",
+            subscription_name="subscription",
+        )
         async def handler(msg: Message) -> None:
             nonlocal received_msg
             received_msg = msg
 
         async with PubSubTestClient(broker) as client:
-            await client.publish({"key": "value", "number": 123}, topic="topic")
+            await client.publish(
+                {"key": "value", "number": 123}, topic="topic"
+            )
 
         assert received_msg is not None
         assert b'"key"' in received_msg.data
@@ -678,7 +835,11 @@ class TestPubSubTestClient:
     async def test_publish_string_data(self, broker: PubSubBroker):
         received_msg: Message | None = None
 
-        @broker.subscriber(alias="str-sub", topic_name="topic", subscription_name="subscription")
+        @broker.subscriber(
+            alias="str-sub",
+            topic_name="topic",
+            subscription_name="subscription",
+        )
         async def handler(msg: Message) -> None:
             nonlocal received_msg
             received_msg = msg
@@ -693,7 +854,11 @@ class TestPubSubTestClient:
     async def test_publish_bytes_data(self, broker: PubSubBroker):
         received_msg: Message | None = None
 
-        @broker.subscriber(alias="bytes-sub", topic_name="topic", subscription_name="subscription")
+        @broker.subscriber(
+            alias="bytes-sub",
+            topic_name="topic",
+            subscription_name="subscription",
+        )
         async def handler(msg: Message) -> None:
             nonlocal received_msg
             received_msg = msg
@@ -710,7 +875,9 @@ class TestPubSubTestClient:
         received_msg: Message | None = None
 
         @broker.subscriber(
-            alias="no-attr-sub", topic_name="topic", subscription_name="subscription"
+            alias="no-attr-sub",
+            topic_name="topic",
+            subscription_name="subscription",
         )
         async def handler(msg: Message) -> None:
             nonlocal received_msg
@@ -723,7 +890,9 @@ class TestPubSubTestClient:
         assert received_msg.attributes == {}
 
     @pytest.mark.asyncio
-    async def test_filter_with_no_attributes_published(self, broker: PubSubBroker):
+    async def test_filter_with_no_attributes_published(
+        self, broker: PubSubBroker
+    ):
         received: list[Message] = []
 
         @broker.subscriber(
@@ -742,7 +911,9 @@ class TestPubSubTestClient:
 
     # Published message dataclass tests
     @pytest.mark.asyncio
-    async def test_published_message_has_project_id(self, broker: PubSubBroker):
+    async def test_published_message_has_project_id(
+        self, broker: PubSubBroker
+    ):
         async with PubSubTestClient(broker) as client:
             await client.publish("test", topic="topic")
 
@@ -752,9 +923,13 @@ class TestPubSubTestClient:
             assert messages[0].project_id == "test-project"
 
     @pytest.mark.asyncio
-    async def test_published_message_with_explicit_project_id(self, broker: PubSubBroker):
+    async def test_published_message_with_explicit_project_id(
+        self, broker: PubSubBroker
+    ):
         async with PubSubTestClient(broker) as client:
-            await client.publish("test", topic="topic", project_id="other-project")
+            await client.publish(
+                "test", topic="topic", project_id="other-project"
+            )
 
             messages = client.get_published_messages()
             assert len(messages) == 1
@@ -762,7 +937,9 @@ class TestPubSubTestClient:
 
     # Cross-project tests
     @pytest.mark.asyncio
-    async def test_cross_project_publish_matches_subscriber(self, broker: PubSubBroker):
+    async def test_cross_project_publish_matches_subscriber(
+        self, broker: PubSubBroker
+    ):
         received: list[Message] = []
 
         @broker.subscriber(
@@ -775,7 +952,9 @@ class TestPubSubTestClient:
             received.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("test", topic="events", project_id="other-project")
+            await client.publish(
+                "test", topic="events", project_id="other-project"
+            )
 
         assert len(received) == 1
         assert received[0].project_id == "other-project"
@@ -796,12 +975,16 @@ class TestPubSubTestClient:
             received.append(msg)
 
         async with PubSubTestClient(broker) as client:
-            await client.publish("test", topic="events")  # defaults to broker project
+            await client.publish(
+                "test", topic="events"
+            )  # defaults to broker project
 
         assert len(received) == 0
 
     @pytest.mark.asyncio
-    async def test_same_topic_different_projects_isolated(self, broker: PubSubBroker):
+    async def test_same_topic_different_projects_isolated(
+        self, broker: PubSubBroker
+    ):
         received_default: list[Message] = []
         received_other: list[Message] = []
 
@@ -824,7 +1007,9 @@ class TestPubSubTestClient:
 
         async with PubSubTestClient(broker) as client:
             await client.publish("msg1", topic="events")  # default project
-            await client.publish("msg2", topic="events", project_id="other-project")
+            await client.publish(
+                "msg2", topic="events", project_id="other-project"
+            )
 
         assert len(received_default) == 1
         assert len(received_other) == 1
@@ -903,15 +1088,21 @@ class TestPubSubTestClient:
             assert ok_results[0].return_value == "ok"
 
     @pytest.mark.asyncio
-    async def test_processing_results_multiple_subscribers(self, broker: PubSubBroker):
+    async def test_processing_results_multiple_subscribers(
+        self, broker: PubSubBroker
+    ):
         @broker.subscriber(
-            alias="sub-a2", topic_name="events", subscription_name="sub-a2-subscription"
+            alias="sub-a2",
+            topic_name="events",
+            subscription_name="sub-a2-subscription",
         )
         async def handler_a(msg: Message) -> None:
             pass
 
         @broker.subscriber(
-            alias="sub-b2", topic_name="events", subscription_name="sub-b2-subscription"
+            alias="sub-b2",
+            topic_name="events",
+            subscription_name="sub-b2-subscription",
         )
         async def handler_b(msg: Message) -> None:
             pass
@@ -925,7 +1116,9 @@ class TestPubSubTestClient:
             assert names == {"handler_a", "handler_b"}
 
     @pytest.mark.asyncio
-    async def test_processing_results_cross_project(self, broker: PubSubBroker):
+    async def test_processing_results_cross_project(
+        self, broker: PubSubBroker
+    ):
         @broker.subscriber(
             alias="proj-default-sub",
             topic_name="events",
@@ -945,7 +1138,9 @@ class TestPubSubTestClient:
 
         async with PubSubTestClient(broker) as client:
             await client.publish("test", topic="events")
-            await client.publish("test", topic="events", project_id="other-project")
+            await client.publish(
+                "test", topic="events", project_id="other-project"
+            )
 
             results = client.get_results()
             assert len(results) == 2
@@ -955,7 +1150,9 @@ class TestPubSubTestClient:
     @pytest.mark.asyncio
     async def test_processing_results_returns_copy(self, broker: PubSubBroker):
         @broker.subscriber(
-            alias="copy-sub", topic_name="events", subscription_name="copy-subscription"
+            alias="copy-sub",
+            topic_name="events",
+            subscription_name="copy-subscription",
         )
         async def handler(msg: Message) -> None:
             pass

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ standard-no-fastapi-cloud-cli = [
 
 [[package]]
 name = "fastpubsub"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The standard in the OSS comunity is line-length at 79 chars. I was using default 100 as if this was a company project. 

## Checklist

- [x] Unit tests and integration tests added
- [x] Documentation updated (required for breaking or minor changes)
- [x] Docs created for new features: snippets, snippet tests, and description on the Zensical website
- [x] Version bumped following semantic versioning (e.g. `0.10.0` → `0.10.1` for a patch, `0.10.0` → `0.11.0` for a minor change, etc).
