### PR TITLE
feat: adds wildcard support for running multiple hierarchical subscribers.

### DIFF
--- a/docs/markdown/tutorial/user-guide/cli.md
+++ b/docs/markdown/tutorial/user-guide/cli.md
@@ -92,6 +92,57 @@ This is useful for:
 - Testing specific handlers in isolation
 - Scaling individual subscribers independently
 
+### Wildcard Patterns
+
+You can use glob patterns to select subscribers by alias prefix, suffix, or hierarchy:
+
+```bash
+# All subscribers under the "orders" prefix
+fastpubsub run my_project.main:app -s 'orders.*'
+
+# All "process" subscribers across any prefix
+fastpubsub run my_project.main:app -s '*.process'
+
+# All subscribers at any depth under "orders"
+fastpubsub run my_project.main:app -s 'orders.**'
+
+# "process" subscribers at any depth
+fastpubsub run my_project.main:app -s '**.process'
+
+# Compose patterns: ** and * together
+fastpubsub run my_project.main:app -s '**.orders.*.process'
+
+# Mix exact names and patterns
+fastpubsub run my_project.main:app -s 'orders.*' -s payments.refund
+```
+
+Given the following application:
+
+```python
+--8<-- "basic_usage/e8_03_cli_wildcards.py:wildcard_subscribers"
+```
+
+The registered aliases are: `orders.process`, `orders.validate`, `orders.notify`, `payments.process`.
+
+| Pattern | Matches |
+|---------|---------|
+| `orders.*` | `orders.process`, `orders.validate`, `orders.notify` |
+| `*.process` | `orders.process`, `payments.process` |
+| `orders.**` | `orders.process`, `orders.validate`, `orders.notify` |
+| `**.process` | `orders.process`, `payments.process` |
+| `order?.*` | `orders.process`, `orders.validate`, `orders.notify` |
+
+**Supported wildcards:**
+
+| Wildcard | Meaning |
+|----------|---------|
+| `*` | Matches any characters within a single segment (between dots) |
+| `?` | Matches exactly one character |
+| `**` | Matches zero or more dot-separated segments |
+
+!!! note
+    If a pattern does not match any subscriber, a warning is logged and the application continues. The application only fails to start if **no subscribers at all** are selected.
+
 ---
 
 ## Production Mode

--- a/docs/snippets/basic_usage/e3_01_linked_pubsub.py
+++ b/docs/snippets/basic_usage/e3_01_linked_pubsub.py
@@ -30,6 +30,6 @@ async def handle_from_another_topic(message: Message) -> None:
 
 
 @app.after_startup
-async def test_publish() -> None:
+async def publish_first_message() -> None:
     publisher = broker.publisher("first-topic")
     await publisher.publish({"hello": "world"})

--- a/docs/snippets/basic_usage/e3_02_subscribers_max_messages.py
+++ b/docs/snippets/basic_usage/e3_02_subscribers_max_messages.py
@@ -30,7 +30,7 @@ async def process_message(message: Message) -> None:
 
 # --8<-- [start:bulk_publish]
 @app.after_startup
-async def test_publish() -> None:
+async def publish_first_message() -> None:
     async with TaskGroup() as tg:
         for _ in range(MAX_MESSAGES * 5):
             tg.create_task(broker.publish("test-topic", "hi!"))

--- a/docs/snippets/basic_usage/e8_03_cli_wildcards.py
+++ b/docs/snippets/basic_usage/e8_03_cli_wildcards.py
@@ -1,0 +1,53 @@
+from fastpubsub import FastPubSub, Message, PubSubBroker, PubSubRouter
+
+broker = PubSubBroker(project_id="your-project-id")
+app = FastPubSub(broker)
+
+orders_router = PubSubRouter(prefix="orders")
+payments_router = PubSubRouter(prefix="payments")
+
+
+# --8<-- [start:wildcard_subscribers]
+@orders_router.subscriber(
+    alias="process",
+    topic_name="new-orders",
+    subscription_name="process-sub",
+)
+async def process_order(message: Message):
+    """Process incoming orders."""
+    pass
+
+
+@orders_router.subscriber(
+    alias="validate",
+    topic_name="new-orders",
+    subscription_name="validate-sub",
+)
+async def validate_order(message: Message):
+    """Validate incoming orders."""
+    pass
+
+
+@orders_router.subscriber(
+    alias="notify",
+    topic_name="order-events",
+    subscription_name="notify-sub",
+)
+async def notify_order(message: Message):
+    """Send order notifications."""
+    pass
+
+
+@payments_router.subscriber(
+    alias="process",
+    topic_name="payment-events",
+    subscription_name="process-sub",
+)
+async def process_payment(message: Message):
+    """Process payments."""
+    pass
+
+
+broker.include_router(orders_router)
+broker.include_router(payments_router)
+# --8<-- [end:wildcard_subscribers]

--- a/docs/snippets/routers/multi_domain_routers/main.py
+++ b/docs/snippets/routers/multi_domain_routers/main.py
@@ -1,7 +1,7 @@
-from fastpubsub import FastPubSub, PubSubBroker
+from posts_domain.routers import posts_router
+from user_domain.routers import users_router
 
-from .posts_domain.routers import posts_router
-from .user_domain.routers import users_router
+from fastpubsub import FastPubSub, PubSubBroker
 
 # --8<-- [start:main_app]
 broker = PubSubBroker(project_id="fastpubsub-pubsub-local")

--- a/docs/snippets/routers/multi_domain_routers/main.py
+++ b/docs/snippets/routers/multi_domain_routers/main.py
@@ -1,7 +1,7 @@
-from posts_domain.routers import posts_router
-from user_domain.routers import users_router
-
 from fastpubsub import FastPubSub, PubSubBroker
+
+from .posts_domain.routers import posts_router
+from .user_domain.routers import users_router
 
 # --8<-- [start:main_app]
 broker = PubSubBroker(project_id="fastpubsub-pubsub-local")

--- a/fastpubsub/_internal/__init__.py
+++ b/fastpubsub/_internal/__init__.py
@@ -1,0 +1,1 @@
+"""Internal implementation modules. Not part of the public API."""

--- a/fastpubsub/_internal/__init__.py
+++ b/fastpubsub/_internal/__init__.py
@@ -1,1 +1,5 @@
 """Internal implementation modules. Not part of the public API."""
+
+from .selector import SubscriberSelector
+
+__all__ = ["SubscriberSelector"]

--- a/fastpubsub/_internal/selector.py
+++ b/fastpubsub/_internal/selector.py
@@ -55,27 +55,31 @@ def _match_segments(pattern: str, alias: str) -> bool:
 
 def _match_parts(
     pattern_parts: tuple[str, ...],
-    pi: int,
+    pattern_index: int,
     alias_parts: tuple[str, ...],
-    ai: int,
+    alias_index: int,
 ) -> bool:
     """Recursive matcher for dot-separated segments."""
-    if pi == len(pattern_parts) and ai == len(alias_parts):
+    if pattern_index == len(pattern_parts) and alias_index == len(alias_parts):
         return True
-    if pi == len(pattern_parts):
+    if pattern_index == len(pattern_parts):
         return False
 
-    if pattern_parts[pi] == "**":
-        for skip in range(ai, len(alias_parts) + 1):
-            if _match_parts(pattern_parts, pi + 1, alias_parts, skip):
+    if pattern_parts[pattern_index] == "**":
+        for skip in range(alias_index, len(alias_parts) + 1):
+            if _match_parts(
+                pattern_parts, pattern_index + 1, alias_parts, skip
+            ):
                 return True
         return False
 
-    if ai == len(alias_parts):
+    if alias_index == len(alias_parts):
         return False
 
-    if fnmatch(alias_parts[ai], pattern_parts[pi]):
-        return _match_parts(pattern_parts, pi + 1, alias_parts, ai + 1)
+    if fnmatch(alias_parts[alias_index], pattern_parts[pattern_index]):
+        return _match_parts(
+            pattern_parts, pattern_index + 1, alias_parts, alias_index + 1
+        )
 
     return False
 

--- a/fastpubsub/_internal/selector.py
+++ b/fastpubsub/_internal/selector.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def _is_glob_pattern(pattern: str) -> bool:
     """Check if a string contains glob characters."""
-    return any(c in pattern for c in ("*", "?", "["))
+    return any(c in pattern for c in ("*", "?"))
 
 
 def _match_pattern(pattern: str, alias: str) -> bool:
@@ -43,14 +43,20 @@ def _match_segments(pattern: str, alias: str) -> bool:
     ``?`` matches a single character (not a dot).
     """
     pattern_parts = pattern.split(".")
+    # Collapse consecutive ** segments to prevent exponential backtracking
+    collapsed: list[str] = []
+    for part in pattern_parts:
+        if part == "**" and collapsed and collapsed[-1] == "**":
+            continue
+        collapsed.append(part)
     alias_parts = alias.split(".")
-    return _match_parts(pattern_parts, 0, alias_parts, 0)
+    return _match_parts(tuple(collapsed), 0, tuple(alias_parts), 0)
 
 
 def _match_parts(
-    pattern_parts: list[str],
+    pattern_parts: tuple[str, ...],
     pi: int,
-    alias_parts: list[str],
+    alias_parts: tuple[str, ...],
     ai: int,
 ) -> bool:
     """Recursive matcher for dot-separated segments."""
@@ -112,7 +118,7 @@ class SubscriberSelector:
             for alias, subscriber in subscribers.items():
                 if alias in seen_aliases:
                     continue
-                if _match_pattern(pattern, alias):
+                if _match_pattern(pattern, alias.lower()):
                     result.append(subscriber)
                     seen_aliases.add(alias)
                     matched = True

--- a/fastpubsub/_internal/selector.py
+++ b/fastpubsub/_internal/selector.py
@@ -1,0 +1,126 @@
+"""Subscriber selection and pattern matching."""
+
+import logging
+from fnmatch import fnmatch
+
+from fastpubsub.pubsub.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+def _is_glob_pattern(pattern: str) -> bool:
+    """Check if a string contains glob characters."""
+    return any(c in pattern for c in ("*", "?", "["))
+
+
+def _match_pattern(pattern: str, alias: str) -> bool:
+    """Match a pattern against a subscriber alias.
+
+    Supports three modes:
+    - Exact match: ``orders.process``
+    - Glob (fnmatch): ``orders.*``, ``order?``
+    - Hierarchical glob: ``**`` matches zero or more
+      dot-separated segments.
+
+    Args:
+        pattern: The user-provided pattern.
+        alias: The subscriber alias to match against.
+
+    Returns:
+        True if the pattern matches the alias.
+    """
+    if not _is_glob_pattern(pattern):
+        return pattern == alias
+
+    return _match_segments(pattern, alias)
+
+
+def _match_segments(pattern: str, alias: str) -> bool:
+    """Match a glob pattern against an alias segment-wise.
+
+    ``**`` matches zero or more dot-separated segments.
+    ``*`` matches within a single segment (no dots).
+    ``?`` matches a single character (not a dot).
+    """
+    pattern_parts = pattern.split(".")
+    alias_parts = alias.split(".")
+    return _match_parts(pattern_parts, 0, alias_parts, 0)
+
+
+def _match_parts(
+    pattern_parts: list[str],
+    pi: int,
+    alias_parts: list[str],
+    ai: int,
+) -> bool:
+    """Recursive matcher for dot-separated segments."""
+    if pi == len(pattern_parts) and ai == len(alias_parts):
+        return True
+    if pi == len(pattern_parts):
+        return False
+
+    if pattern_parts[pi] == "**":
+        for skip in range(ai, len(alias_parts) + 1):
+            if _match_parts(pattern_parts, pi + 1, alias_parts, skip):
+                return True
+        return False
+
+    if ai == len(alias_parts):
+        return False
+
+    if fnmatch(alias_parts[ai], pattern_parts[pi]):
+        return _match_parts(pattern_parts, pi + 1, alias_parts, ai + 1)
+
+    return False
+
+
+class SubscriberSelector:
+    """Selects subscribers from a registry by patterns.
+
+    Supports exact aliases, glob patterns (``*``, ``?``),
+    and hierarchical glob (``**``) for matching against
+    dot-separated subscriber aliases.
+
+    Args:
+        patterns: Set of patterns to match. Empty means all.
+    """
+
+    def __init__(self, patterns: set[str]) -> None:
+        self._patterns = {p.lower().strip() for p in patterns if p.strip()}
+
+    def select(self, subscribers: dict[str, Subscriber]) -> list[Subscriber]:
+        """Select subscribers matching configured patterns.
+
+        Args:
+            subscribers: Registry of alias -> Subscriber.
+
+        Returns:
+            List of matched subscribers without duplicates.
+        """
+        if not self._patterns:
+            logger.debug(
+                "Running all subscribers: %s",
+                list(subscribers.keys()),
+            )
+            return list(subscribers.values())
+
+        seen_aliases: set[str] = set()
+        result: list[Subscriber] = []
+
+        for pattern in self._patterns:
+            matched = False
+            for alias, subscriber in subscribers.items():
+                if alias in seen_aliases:
+                    continue
+                if _match_pattern(pattern, alias):
+                    result.append(subscriber)
+                    seen_aliases.add(alias)
+                    matched = True
+
+            if not matched:
+                logger.warning(
+                    "Pattern '%s' did not match any subscriber",
+                    pattern,
+                )
+
+        return result

--- a/fastpubsub/broker.py
+++ b/fastpubsub/broker.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, validate_call
 
+from fastpubsub._internal.selector import SubscriberSelector
 from fastpubsub.builder import PubSubSubscriptionBuilder
 from fastpubsub.concurrency.manager import AsyncTaskManager
 from fastpubsub.exceptions import FastPubSubException
@@ -262,42 +263,20 @@ class PubSubBroker:
 
     def _filter_subscribers(self) -> list[Subscriber]:
         subscribers = self.router._get_subscribers()
-        selected_subscribers = self._get_selected_subscribers()
-
-        if not selected_subscribers:
-            logger.debug(
-                f"Running all the subscribers as {list(subscribers.keys())}"
-            )
-            return list(subscribers.values())
-
-        found_subscribers = []
-        for selected_subscriber in selected_subscribers:
-            if selected_subscriber not in subscribers:
-                logger.warning(
-                    f"The '{selected_subscriber}' subscriber alias not found"
-                )
-                continue
-
-            logger.debug(
-                f"We have found the subscriber '{selected_subscriber}'"
-            )
-            found_subscribers.append(subscribers[selected_subscriber])
-
-        return found_subscribers
+        patterns = self._get_selected_subscribers()
+        selector = SubscriberSelector(patterns=patterns)
+        return selector.select(subscribers)
 
     def _get_selected_subscribers(self) -> set[str]:
-        selected_subscribers: set[str] = set()
         subscribers_text = os.getenv("FASTPUBSUB_SUBSCRIBERS", "")
         if not subscribers_text:
-            return selected_subscribers
+            return set()
 
-        dirty_aliases = subscribers_text.split(",")
-        for dirty_alias in dirty_aliases:
-            clean_alias = dirty_alias.lower().strip()
-            if clean_alias:
-                selected_subscribers.add(clean_alias)
-
-        return selected_subscribers
+        return {
+            alias.lower().strip()
+            for alias in subscribers_text.split(",")
+            if alias.strip()
+        }
 
     async def shutdown(self) -> None:
         """Gracefully shuts down the broker using the configured timeout."""

--- a/fastpubsub/broker.py
+++ b/fastpubsub/broker.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, validate_call
 
-from fastpubsub._internal.selector import SubscriberSelector
+from fastpubsub._internal import SubscriberSelector
 from fastpubsub.builder import PubSubSubscriptionBuilder
 from fastpubsub.concurrency.manager import AsyncTaskManager
 from fastpubsub.exceptions import FastPubSubException
@@ -273,7 +273,7 @@ class PubSubBroker:
             return set()
 
         return {
-            alias.lower().strip()
+            alias.strip()
             for alias in subscribers_text.split(",")
             if alias.strip()
         }

--- a/fastpubsub/router.py
+++ b/fastpubsub/router.py
@@ -198,7 +198,7 @@ class PubSubRouter:
                     f"{self.prefix}.{prefixed_subscription_name}"
                 )
 
-            if prefixed_alias in self.subscribers:
+            if prefixed_alias.lower() in self.subscribers:
                 raise FastPubSubException(
                     f"The alias '{prefixed_alias}' already exists."
                     " The alias must be unique among all subscribers"
@@ -373,4 +373,4 @@ class PubSubRouter:
 
             old_alias = alias.split(".")[-1]
             new_prefixed_alias = f"{self.prefix}.{old_alias}"
-            self.subscribers[new_prefixed_alias] = subscriber
+            self.subscribers[new_prefixed_alias.lower()] = subscriber

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ export PYTHONPATH := "docs/snippets:${PYTHONPATH}"
 [group("tests")]
 @test-unit *args: (up "--no-deps fastpubsub") && down
     just _start_msg "Running unit tests"
-    {{ run_test_command }} pytest -m "not connected and not slow" -n auto --tb=short {{ args }}
+    {{ run_test_command }} pytest -m "not (connected or slow or docs)" -n auto --tb=short {{ args }}
 
 [doc("Run integration tests (requires emulator)")]
 [group("tests")]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "fastpubsub"
 description = "FastPubSub: A high-performance, asyncio-native framework for Google Cloud Pub/Sub applications"
 readme = "README.md"
-version = "0.9.3"
+version = "0.9.4"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/tests/docs/basic_usage/test_cli_wildcards.py
+++ b/tests/docs/basic_usage/test_cli_wildcards.py
@@ -1,0 +1,38 @@
+"""Tests for CLI wildcard subscriber snippet."""
+
+from __future__ import annotations
+
+import pytest
+
+from docs.snippets.basic_usage.e8_03_cli_wildcards import broker
+from fastpubsub._internal.selector import SubscriberSelector
+
+
+@pytest.mark.docs
+class TestCLIWildcardSnippet:
+    """Verify the wildcard snippet registers expected aliases."""
+
+    def test_all_aliases_registered(self) -> None:
+        subscribers = broker.router._get_subscribers()
+        assert "orders.process" in subscribers
+        assert "orders.validate" in subscribers
+        assert "orders.notify" in subscribers
+        assert "payments.process" in subscribers
+
+    def test_wildcard_orders_star(self) -> None:
+        subscribers = broker.router._get_subscribers()
+        selector = SubscriberSelector(patterns={"orders.*"})
+        result = selector.select(subscribers)
+        assert len(result) == 3
+
+    def test_wildcard_star_process(self) -> None:
+        subscribers = broker.router._get_subscribers()
+        selector = SubscriberSelector(patterns={"*.process"})
+        result = selector.select(subscribers)
+        assert len(result) == 2
+
+    def test_wildcard_double_star_process(self) -> None:
+        subscribers = broker.router._get_subscribers()
+        selector = SubscriberSelector(patterns={"**.process"})
+        result = selector.select(subscribers)
+        assert len(result) == 2

--- a/tests/docs/basic_usage/test_linked_pubsub.py
+++ b/tests/docs/basic_usage/test_linked_pubsub.py
@@ -1,6 +1,9 @@
 import pytest
 
-from docs.snippets.basic_usage.e3_01_linked_pubsub import broker, test_publish
+from docs.snippets.basic_usage.e3_01_linked_pubsub import (
+    broker,
+    publish_first_message,
+)
 from fastpubsub.testing import PubSubTestClient
 
 
@@ -11,7 +14,7 @@ class TestLinkedPubsub:
         self,
     ) -> None:
         async with PubSubTestClient(broker) as client:
-            await test_publish()
+            await publish_first_message()
             published_messages = client.get_published_messages()
             results = client.get_results()
 

--- a/tests/docs/basic_usage/test_subscribers_max_messages.py
+++ b/tests/docs/basic_usage/test_subscribers_max_messages.py
@@ -5,7 +5,7 @@ import pytest
 from docs.snippets.basic_usage.e3_02_subscribers_max_messages import (
     MAX_MESSAGES,
     broker,
-    test_publish,
+    publish_first_message,
 )
 from fastpubsub.testing import PubSubTestClient
 
@@ -23,7 +23,7 @@ class TestSubscribersMaxMessages:
         monkeypatch.setattr(f"{_SNIPPET}.asyncio.sleep", sleep)
 
         async with PubSubTestClient(broker) as client:
-            await test_publish()
+            await publish_first_message()
             published_messages = client.get_published_messages()
             results = client.get_results()
 

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -110,6 +110,33 @@ class TestPubSubBroker:
         finally:
             os.environ["FASTPUBSUB_SUBSCRIBERS"] = ""
 
+    @pytest.mark.parametrize(
+        ("selected_subscribers", "expected_count"),
+        [
+            ("a.*", 2),
+            ("**.x", 2),
+            ("a.?", 2),
+        ],
+    )
+    async def test_filter_subscribers_with_wildcards(
+        self,
+        broker: PubSubBroker,
+        selected_subscribers: str,
+        expected_count: int,
+    ) -> None:
+        try:
+            os.environ["FASTPUBSUB_SUBSCRIBERS"] = selected_subscribers
+            broker.router = MagicMock()
+            broker.router._get_subscribers.return_value = {
+                "a.x": "ax",
+                "a.y": "ay",
+                "b.x": "bx",
+            }
+            found = broker._filter_subscribers()
+            assert len(found) == expected_count
+        finally:
+            os.environ["FASTPUBSUB_SUBSCRIBERS"] = ""
+
     @pytest.mark.asyncio
     async def test_shutdown_successfully(
         self, async_task_manager: MagicMock, broker: PubSubBroker

--- a/tests/unit/test_subscriber_selector.py
+++ b/tests/unit/test_subscriber_selector.py
@@ -1,0 +1,216 @@
+"""Tests for SubscriberSelector."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from fastpubsub._internal.selector import SubscriberSelector
+from fastpubsub.pubsub.subscriber import Subscriber
+
+
+def _make_subscriber(name: str) -> MagicMock:
+    """Create a mock subscriber with a given name."""
+    mock = MagicMock(spec=Subscriber)
+    mock.name = name
+    return mock
+
+
+class TestSubscriberSelectorExactMatch:
+    """Tests for exact alias matching."""
+
+    def test_empty_patterns_returns_all(self) -> None:
+        subs = {
+            "a": _make_subscriber("a"),
+            "b": _make_subscriber("b"),
+        }
+        selector = SubscriberSelector(patterns=set())
+        result = selector.select(subs)
+        assert len(result) == 2
+
+    def test_exact_match_single(self) -> None:
+        subs = {
+            "a": _make_subscriber("a"),
+            "b": _make_subscriber("b"),
+        }
+        selector = SubscriberSelector(patterns={"a"})
+        result = selector.select(subs)
+        assert len(result) == 1
+        assert result[0].name == "a"
+
+    def test_exact_match_multiple(self) -> None:
+        subs = {
+            "a": _make_subscriber("a"),
+            "b": _make_subscriber("b"),
+        }
+        selector = SubscriberSelector(patterns={"a", "b"})
+        result = selector.select(subs)
+        assert len(result) == 2
+
+    def test_exact_match_not_found_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        subs = {"a": _make_subscriber("a")}
+        selector = SubscriberSelector(patterns={"a", "nonexistent"})
+        fps_logger = logging.getLogger("fastpubsub")
+        fps_logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING):
+                result = selector.select(subs)
+        finally:
+            fps_logger.propagate = False
+        assert len(result) == 1
+        assert "nonexistent" in caplog.text
+
+    def test_no_match_at_all_returns_empty(self) -> None:
+        subs = {"a": _make_subscriber("a")}
+        selector = SubscriberSelector(patterns={"x"})
+        result = selector.select(subs)
+        assert len(result) == 0
+
+    def test_case_insensitive(self) -> None:
+        subs = {"orders.process": _make_subscriber("process")}
+        selector = SubscriberSelector(patterns={"Orders.Process"})
+        result = selector.select(subs)
+        assert len(result) == 1
+
+    def test_no_duplicates(self) -> None:
+        subs = {"a": _make_subscriber("a")}
+        selector = SubscriberSelector(patterns={"a"})
+        result = selector.select(subs)
+        assert len(result) == 1
+
+
+class TestSubscriberSelectorGlobMatch:
+    """Tests for single-star and question-mark glob patterns."""
+
+    @pytest.fixture
+    def subscribers(self) -> dict[str, MagicMock]:
+        return {
+            "orders.process": _make_subscriber("process"),
+            "orders.validate": _make_subscriber("validate"),
+            "orders.notify": _make_subscriber("notify"),
+            "payments.process": _make_subscriber("pay_process"),
+            "payments.refund": _make_subscriber("refund"),
+        }
+
+    def test_star_matches_within_segment(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"orders.*"})
+        result = selector.select(subscribers)
+        assert len(result) == 3
+        names = {s.name for s in result}
+        assert names == {"process", "validate", "notify"}
+
+    def test_star_does_not_cross_segments(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        subscribers["orders.br.process"] = _make_subscriber("br_process")
+        selector = SubscriberSelector(patterns={"orders.*"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert "br_process" not in names
+
+    def test_question_mark(self, subscribers: dict[str, MagicMock]) -> None:
+        selector = SubscriberSelector(patterns={"orders.proc?ss"})
+        result = selector.select(subscribers)
+        assert len(result) == 1
+        assert result[0].name == "process"
+
+    def test_star_prefix_match(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"*.process"})
+        result = selector.select(subscribers)
+        assert len(result) == 2
+        names = {s.name for s in result}
+        assert names == {"process", "pay_process"}
+
+
+class TestSubscriberSelectorDoubleStarMatch:
+    """Tests for ** hierarchical glob patterns."""
+
+    @pytest.fixture
+    def subscribers(self) -> dict[str, MagicMock]:
+        return {
+            "process": _make_subscriber("root_process"),
+            "orders.process": _make_subscriber("orders_process"),
+            "v1.orders.process": _make_subscriber("v1_process"),
+            "v1.orders.br.process": _make_subscriber("v1_br_process"),
+            "orders.validate": _make_subscriber("validate"),
+            "payments.process": _make_subscriber("pay_process"),
+        }
+
+    def test_double_star_suffix(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"orders.**"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert names == {"orders_process", "validate"}
+
+    def test_double_star_prefix(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"**.process"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert names == {
+            "root_process",
+            "orders_process",
+            "v1_process",
+            "v1_br_process",
+            "pay_process",
+        }
+
+    def test_double_star_middle(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"v1.**.process"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert names == {"v1_process", "v1_br_process"}
+
+    def test_double_star_composed(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"**.orders.*.process"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert names == {"v1_br_process"}
+
+    def test_double_star_zero_segments(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"**.orders.process"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert "orders_process" in names
+        assert "v1_process" in names
+
+    def test_multiple_patterns_union(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"orders.*", "payments.*"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert names == {
+            "orders_process",
+            "validate",
+            "pay_process",
+        }
+
+    def test_mixed_exact_and_glob(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"process", "orders.*"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert names == {
+            "root_process",
+            "orders_process",
+            "validate",
+        }

--- a/tests/unit/test_subscriber_selector.py
+++ b/tests/unit/test_subscriber_selector.py
@@ -76,6 +76,13 @@ class TestSubscriberSelectorExactMatch:
         result = selector.select(subs)
         assert len(result) == 1
 
+    def test_case_insensitive_mixed_case_alias(self) -> None:
+        subs = {"Orders.Process": _make_subscriber("process")}
+        selector = SubscriberSelector(patterns={"orders.*"})
+        result = selector.select(subs)
+        assert len(result) == 1
+        assert result[0].name == "process"
+
     def test_no_duplicates(self) -> None:
         subs = {"a": _make_subscriber("a")}
         selector = SubscriberSelector(patterns={"a"})
@@ -200,6 +207,20 @@ class TestSubscriberSelectorDoubleStarMatch:
         assert names == {
             "orders_process",
             "validate",
+            "pay_process",
+        }
+
+    def test_consecutive_double_stars_collapsed(
+        self, subscribers: dict[str, MagicMock]
+    ) -> None:
+        selector = SubscriberSelector(patterns={"**.**.process"})
+        result = selector.select(subscribers)
+        names = {s.name for s in result}
+        assert names == {
+            "root_process",
+            "orders_process",
+            "v1_process",
+            "v1_br_process",
             "pay_process",
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ standard-no-fastapi-cloud-cli = [
 
 [[package]]
 name = "fastpubsub"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

For a long time, we did not have a way of running multiple hierarchical subscriber without calling all the subscribers or a list of specific subscriber. This PR adds the functionality to call subscribers using wildcards and question marks (*, ?).


## Checklist

- [X] Unit tests and integration tests added
- [X] Documentation updated (required for breaking or minor changes)
- [X] Docs created for new features: snippets, snippet tests, and description on the Zensical website
- [X] Version bumped following semantic versioning (e.g. `0.10.0` → `0.10.1` for a patch, `0.10.0` → `0.11.0` for a minor change, etc).
