### PR TITLE
feat: add `fastpubsub inspect subscribers` command

### DIFF
--- a/docs/markdown/advanced/index.md
+++ b/docs/markdown/advanced/index.md
@@ -1,7 +1,3 @@
----
-icon: lucide/flask-conical
----
-
 # Advanced Usage
 
 This section consolidates FastPubSub capabilities that are typically adopted after the core development workflow is already stable.

--- a/docs/markdown/tutorial/user-guide/cli.md
+++ b/docs/markdown/tutorial/user-guide/cli.md
@@ -196,7 +196,7 @@ The framework is actively developed with planned features:
 
 - **Full Support for Uvicorn**: At the moment we only support a few set of basic configurations for uvicorn. We intend to support them all in the future.
 - **Publish Messages**: Publish messages locally to the configured emulator or directly sending to your handler.
-- **Listing FastPubSub Components**: Different strategies to list your routers, subscribers, publishers, etc.
+- **Inspecting Components**: See [Inspecting Your Application](inspect.md) for listing subscribers, topics, and more.
 
 ---
 

--- a/docs/markdown/tutorial/user-guide/inspect.md
+++ b/docs/markdown/tutorial/user-guide/inspect.md
@@ -1,0 +1,230 @@
+---
+icon: lucide/search
+---
+
+# Inspecting Your Application
+
+As your application grows — more subscribers, more routers, more topics — it becomes hard to remember how everything is wired together. The `inspect` command gives you a quick overview of your application's subscribers without starting the server or connecting to Google Cloud.
+
+## How It Works
+
+When you run `fastpubsub inspect subscribers`, the CLI:
+
+1. **Imports your application** using the `module:attribute` path you provide
+2. **Reads the subscriber registry** from your broker's router hierarchy
+3. **Formats the output** as a table (default) or JSON
+4. **Exits** — no server starts, no lifecycle hooks fire, no Pub/Sub connections open
+
+---
+
+## Basic Usage
+
+Consider an e-commerce application that processes orders, charges payments, and sends notifications:
+
+```python
+--8<-- "basic_usage/e9_01_inspect_basic.py:inspect_basic_subscribers"
+```
+
+Run the inspect command to see what your application registers:
+
+```bash
+fastpubsub inspect subscribers my_project.main:app
+```
+
+Output:
+
+```
+FastPubSub (v0.9.5): my_project.main:app — 3 subscribers
+
+┌─────────────────────┬─────────────────┬──────────────────────┬─────────────────────┬───────────────────┐
+│ Alias               │ Project         │ Topic                │ Subscription        │ Handler           │
+├─────────────────────┼─────────────────┼──────────────────────┼─────────────────────┼───────────────────┤
+│ charge-payments     │ ecommerce-prod  │ payment-events       │ payments-sub        │ charge_payment    │
+│ process-orders      │ ecommerce-prod  │ order-events         │ orders-sub          │ process_order     │
+│ send-notifications  │ ecommerce-prod  │ notification-events  │ notifications-sub   │ send_notification │
+└─────────────────────┴─────────────────┴──────────────────────┴─────────────────────┴───────────────────┘
+```
+
+Subscribers are sorted alphabetically by alias.
+
+---
+
+## Selecting Columns
+
+By default, the table shows five columns: **alias**, **project**, **topic**, **subscription**, and **handler**. Use `--columns` (or `-c`) to choose exactly which columns appear.
+
+### Core Columns
+
+These are shown by default when no `--columns` flag is provided:
+
+| Column | Description |
+|--------|-------------|
+| `alias` | The subscriber's unique identifier, including router prefixes |
+| `project` | The Google Cloud project ID |
+| `topic` | The Pub/Sub topic name |
+| `subscription` | The Pub/Sub subscription name |
+| `handler` | The Python function name that processes messages |
+
+### Policy Columns
+
+These are available when you need deeper visibility into subscriber configuration:
+
+| Column | Description |
+|--------|-------------|
+| `ack_deadline` | Acknowledgement deadline in seconds |
+| `filter` | Pub/Sub filter expression |
+| `ordering` | Whether message ordering is enabled |
+| `exactly_once` | Whether exactly-once delivery is enabled |
+| `max_messages` | Maximum concurrent messages in flight |
+| `retry_min` | Minimum retry backoff delay in seconds |
+| `retry_max` | Maximum retry backoff delay in seconds |
+| `dead_letter_topic` | Dead letter topic name (empty if none) |
+| `dead_letter_max_attempts` | Max delivery attempts before dead-lettering |
+| `autocreate` | Whether topics/subscriptions are auto-created on startup |
+| `autoupdate` | Whether subscriptions are auto-updated on startup |
+
+### Examples
+
+Show only alias and topic:
+
+```bash
+fastpubsub inspect subscribers my_project.main:app --columns alias,topic
+```
+
+Show all columns including policy fields:
+
+```bash
+fastpubsub inspect subscribers my_project.main:app --columns all
+```
+
+Show specific policy columns alongside the alias:
+
+```bash
+fastpubsub inspect subscribers my_project.main:app -c alias,topic,dead_letter_topic,exactly_once
+```
+
+!!! note
+
+    Column names are case-insensitive and extra whitespace is ignored. `--columns " Alias , Topic "` works the same as `--columns alias,topic`.
+
+---
+
+## JSON Output
+
+Use `--format json` (or `-f json`) for machine-readable output. This is useful for scripting, CI pipelines, or feeding into other tools.
+
+```bash
+fastpubsub inspect subscribers my_project.main:app --format json
+```
+
+```json
+{
+  "app": "my_project.main:app",
+  "version": "0.9.5",
+  "subscribers": [
+    {
+      "alias": "charge-payments",
+      "project": "ecommerce-prod",
+      "topic": "payment-events",
+      "subscription": "payments-sub",
+      "handler": "charge_payment"
+    }
+  ]
+}
+```
+
+The `--columns` flag works with JSON too — it controls which fields appear in each subscriber object:
+
+```bash
+# Extract just aliases with jq
+fastpubsub inspect subscribers my_project.main:app -f json | jq '.subscribers[].alias'
+
+# Get a compact alias-to-topic mapping
+fastpubsub inspect subscribers my_project.main:app -f json -c alias,topic \
+  | jq '.subscribers[] | "\(.alias) → \(.topic)"'
+```
+
+---
+
+## Filtering Subscribers
+
+Use `--filter` to show only subscribers whose alias matches a glob pattern. This is useful when your application has many subscribers and you want to focus on a specific group.
+
+```bash
+# Show only order-related subscribers
+fastpubsub inspect subscribers my_project.main:app --filter 'process-*'
+
+# Multiple patterns (union)
+fastpubsub inspect subscribers my_project.main:app --filter 'process-*' --filter 'send-*'
+```
+
+The `--filter` flag supports the same glob patterns as `run --subscribers`:
+
+| Wildcard | Meaning |
+|----------|---------|
+| `*` | Matches any characters within a single segment (between dots) |
+| `?` | Matches exactly one character |
+| `**` | Matches zero or more dot-separated segments |
+
+!!! tip "Dry-run your subscriber selection"
+
+    Use `inspect subscribers --filter` to **preview which subscribers a pattern matches** before passing the same pattern to `run --subscribers`. This way you can verify your pattern selects exactly the right subscribers — without starting the server.
+
+    ```bash
+    # Step 1: Check which subscribers the pattern matches
+    fastpubsub inspect subscribers my_project.main:app --filter 'platform.orders.*'
+
+    # Step 2: Looks good — now run with the same pattern
+    fastpubsub run my_project.main:app -s 'platform.orders.*'
+    ```
+
+---
+
+## Inspecting Apps with Routers
+
+When your application uses [routers](routers.md) with prefixes, subscriber aliases are prefixed automatically. The inspect command reveals the full resolved alias, making it easy to understand the hierarchy.
+
+Consider a SaaS platform with nested routers:
+
+```python
+--8<-- "basic_usage/e9_02_inspect_routers.py:inspect_router_subscribers"
+```
+
+```bash
+fastpubsub inspect subscribers saas.main:app
+```
+
+```
+FastPubSub (v0.9.5): saas.main:app — 3 subscribers
+
+┌──────────────────────────────┬──────────────────────┬──────────────────┬──────────────────┬────────────────┐
+│ Alias                        │ Project              │ Topic            │ Subscription     │ Handler        │
+├──────────────────────────────┼──────────────────────┼──────────────────┼──────────────────┼────────────────┤
+│ platform.analytics.track     │ analytics-warehouse  │ analytics-events │ ...track-sub     │ track_event    │
+│ platform.orders.fulfill      │ saas-platform        │ order-events     │ ...fulfill-sub   │ fulfill_order  │
+│ platform.orders.invoice      │ saas-platform        │ order-events     │ ...invoice-sub   │ create_invoice │
+└──────────────────────────────┴──────────────────────┴──────────────────┴──────────────────┴────────────────┘
+```
+
+Notice how:
+
+- The `platform` prefix from the top-level router appears first in every alias
+- The `orders` and `analytics` prefixes from the child routers follow
+- The `track` subscriber shows a different project (`analytics-warehouse`) — the inspect command makes cross-project subscriptions visible at a glance
+
+!!! tip
+
+    The aliases shown by `inspect` are the same strings you pass to `--subscribers` when running the app. Use `inspect` to find the exact alias, then copy it into your `run` command.
+
+---
+
+## Recap
+
+- **Command**: `fastpubsub inspect subscribers module:app` lists all subscribers
+- **Default columns**: alias, project, topic, subscription, handler
+- **Custom columns**: `--columns alias,topic` replaces the default set; `--columns all` shows everything
+- **Filtering**: `--filter 'pattern'` shows only matching subscribers — use it as a dry-run for `run --subscribers`
+- **JSON output**: `--format json` for scripting and CI pipelines
+- **No side effects**: the command imports your app but does not start the server or connect to Pub/Sub
+- **Router prefixes**: aliases reflect the full router prefix hierarchy
+- **Sorted output**: subscribers are always sorted alphabetically by alias

--- a/docs/snippets/basic_usage/e0_01_first_steps.py
+++ b/docs/snippets/basic_usage/e0_01_first_steps.py
@@ -11,7 +11,6 @@ class Address(BaseModel):
 
 
 # --8<-- [end:pydantic_model]
-
 # --8<-- [start:broker_app]
 broker = PubSubBroker(project_id="your-project-id")
 app = FastPubSub(broker)
@@ -27,8 +26,6 @@ async def create_address(address: Address):
 
 
 # --8<-- [end:rest_endpoint]
-
-
 # --8<-- [start:subscriber]
 @broker.subscriber(
     alias="address-handler",

--- a/docs/snippets/basic_usage/e1_01_basic_subscriber.py
+++ b/docs/snippets/basic_usage/e1_01_basic_subscriber.py
@@ -27,8 +27,6 @@ async def handle_message(message: Message):
 
 
 # --8<-- [end:basic_subscriber]
-
-
 # --8<-- [start:basic_subscriber_startup]
 @app.after_startup
 async def publish_initial_message() -> None:

--- a/docs/snippets/basic_usage/e9_01_inspect_basic.py
+++ b/docs/snippets/basic_usage/e9_01_inspect_basic.py
@@ -1,0 +1,43 @@
+from fastpubsub import FastPubSub, Message, PubSubBroker
+
+broker = PubSubBroker(project_id="ecommerce-prod")
+app = FastPubSub(broker)
+
+
+# --8<-- [start:inspect_basic_subscribers]
+@broker.subscriber(
+    alias="process-orders",
+    topic_name="order-events",
+    subscription_name="orders-sub",
+    ack_deadline_seconds=120,
+    dead_letter_topic="order-events-dlq",
+    max_delivery_attempts=5,
+)
+async def process_order(message: Message):
+    """Validate and fulfill incoming orders."""
+    ...
+
+
+@broker.subscriber(
+    alias="charge-payments",
+    topic_name="payment-events",
+    subscription_name="payments-sub",
+    enable_exactly_once_delivery=True,
+)
+async def charge_payment(message: Message):
+    """Process payment charges with exactly-once guarantees."""
+    ...
+
+
+@broker.subscriber(
+    alias="send-notifications",
+    topic_name="notification-events",
+    subscription_name="notifications-sub",
+    filter_expression='attributes.channel = "email"',
+)
+async def send_notification(message: Message):
+    """Send email notifications filtered by channel attribute."""
+    ...
+
+
+# --8<-- [end:inspect_basic_subscribers]

--- a/docs/snippets/basic_usage/e9_02_inspect_routers.py
+++ b/docs/snippets/basic_usage/e9_02_inspect_routers.py
@@ -1,0 +1,53 @@
+from fastpubsub import (
+    FastPubSub,
+    Message,
+    PubSubBroker,
+    PubSubRouter,
+)
+
+broker = PubSubBroker(project_id="saas-platform")
+app = FastPubSub(broker)
+
+
+# --8<-- [start:inspect_router_subscribers]
+orders_router = PubSubRouter(prefix="orders")
+analytics_router = PubSubRouter(prefix="analytics")
+platform_router = PubSubRouter(
+    prefix="platform",
+    routers=[orders_router, analytics_router],
+)
+
+
+@orders_router.subscriber(
+    alias="fulfill",
+    topic_name="order-events",
+    subscription_name="fulfill-sub",
+)
+async def fulfill_order(message: Message):
+    """Pick, pack, and ship the order."""
+    ...
+
+
+@orders_router.subscriber(
+    alias="invoice",
+    topic_name="order-events",
+    subscription_name="invoice-sub",
+)
+async def create_invoice(message: Message):
+    """Generate and store the invoice."""
+    ...
+
+
+@analytics_router.subscriber(
+    alias="track",
+    topic_name="analytics-events",
+    subscription_name="track-sub",
+    project_id="analytics-warehouse",
+)
+async def track_event(message: Message):
+    """Forward events to the analytics data warehouse."""
+    ...
+
+
+broker.include_router(platform_router)
+# --8<-- [end:inspect_router_subscribers]

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -31,6 +31,7 @@ nav = [
             { "Middlewares" = "tutorial/user-guide/middlewares.md" },
             { "Message Lifecycle and Acknowledgement" = "tutorial/user-guide/lifecycle.md" },
             { "Command-Line Interface (CLI)" = "tutorial/user-guide/cli.md" },
+            { "Inspecting Your Application" = "tutorial/user-guide/inspect.md" },
             { "Testing" = "tutorial/user-guide/testing.md" },
             { "Deployment" = "tutorial/user-guide/deployment.md"},
             { "Observability" = "tutorial/user-guide/observability.md"},

--- a/fastpubsub/broker.py
+++ b/fastpubsub/broker.py
@@ -262,7 +262,7 @@ class PubSubBroker:
         return True
 
     def _filter_subscribers(self) -> list[Subscriber]:
-        subscribers = self.router._get_subscribers()
+        subscribers = self.router.get_subscribers()
         patterns = self._get_selected_subscribers()
         selector = SubscriberSelector(patterns=patterns)
         return selector.select(subscribers)

--- a/fastpubsub/cli/inspect.py
+++ b/fastpubsub/cli/inspect.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from fastpubsub.__about__ import __version__
 from fastpubsub._internal import SubscriberSelector
 from fastpubsub.applications import FastPubSub
+from fastpubsub.exceptions import FastPubSubCLIException
 from fastpubsub.pubsub.subscriber import Subscriber
 
 inspect_app = typer.Typer(
@@ -108,7 +109,7 @@ def resolve_columns(columns_arg: str | None) -> list[str]:
         A list of validated column names.
 
     Raises:
-        typer.BadParameter: If any column name is unknown.
+        FastPubSubCLIException: If any column name is unknown.
     """
     if columns_arg is None:
         return list(DEFAULT_COLUMNS)
@@ -122,12 +123,9 @@ def resolve_columns(columns_arg: str | None) -> list[str]:
     unknown = [t for t in tokens if t not in SubscriberRecord.model_fields]
     if unknown:
         available = ", ".join(ALL_COLUMNS)
-        typer.echo(
-            f"Error: Unknown column(s): {', '.join(unknown)}. "
-            f"Available: {available}",
-            err=True,
+        raise FastPubSubCLIException(
+            f"Unknown column(s): {', '.join(unknown)}. Available: {available}"
         )
-        raise SystemExit(1)
 
     return tokens
 
@@ -164,9 +162,10 @@ class SubscriberInspector:
         records = self._build_records()
 
         if output_format == "json":
-            return self._print_json(records)
+            self._print_json(records)
+            return
 
-        return self._print_table(records)
+        self._print_table(records)
 
     def _build_records(self) -> list[SubscriberRecord]:
         """Build sorted SubscriberRecord list from the app.
@@ -179,10 +178,11 @@ class SubscriberInspector:
         if self.filter_patterns:
             selector = SubscriberSelector(patterns=self.filter_patterns)
             filtered_list = selector.select(subscribers)
+            filtered_ids = {id(s) for s in filtered_list}
             subscribers = {
                 alias: sub
                 for alias, sub in subscribers.items()
-                if sub in filtered_list
+                if id(sub) in filtered_ids
             }
 
         return sorted(

--- a/fastpubsub/cli/inspect.py
+++ b/fastpubsub/cli/inspect.py
@@ -233,12 +233,3 @@ class SubscriberInspector:
             ],
         }
         typer.echo(json.dumps(output, indent=2, default=str))
-
-
-# Future inspect subcommands:
-# - inspect topics: list unique topics and their subscribers (fan-out view)
-# - inspect publishers: list registered publishers and target topics
-# - inspect routes: show router hierarchy, prefixes, and nesting
-# - inspect middlewares: show middleware chains per subscriber and global
-# - inspect policies: summary table of retry, DLT, and delivery policies
-# - inspect config: resolved runtime config (project, host, port, env vars)

--- a/fastpubsub/cli/inspect.py
+++ b/fastpubsub/cli/inspect.py
@@ -10,13 +10,7 @@ from rich.table import Table
 
 from fastpubsub.__about__ import __version__
 from fastpubsub._internal import SubscriberSelector
-from fastpubsub.cli.options import (
-    AppArgument,
-    InspectColumnsOption,
-    InspectFilterOption,
-    InspectFormatOption,
-)
-from fastpubsub.cli.utils import import_app
+from fastpubsub.applications import FastPubSub
 from fastpubsub.pubsub.subscriber import Subscriber
 
 inspect_app = typer.Typer(
@@ -25,7 +19,13 @@ inspect_app = typer.Typer(
     rich_markup_mode="markdown",
 )
 
-DEFAULT_COLUMNS = ["alias", "project", "topic", "subscription", "handler"]
+DEFAULT_COLUMNS = [
+    "alias",
+    "project",
+    "topic",
+    "subscription",
+    "handler",
+]
 
 
 class SubscriberRecord(BaseModel):
@@ -132,100 +132,107 @@ def resolve_columns(columns_arg: str | None) -> list[str]:
     return tokens
 
 
-def _format_table(
-    app_path: str,
-    records: list[SubscriberRecord],
-    columns: list[str],
-) -> None:
-    """Print subscribers as a Rich table.
+class SubscriberInspector:
+    """Inspects subscribers of a FastPubSub application."""
 
-    Args:
-        app_path: The module:attribute path for the header.
-        records: List of SubscriberRecord to display.
-        columns: Column names to include.
-    """
-    count = len(records)
-    header = (
-        f"[bold]FastPubSub[/bold] (v{__version__}): "
-        f"{app_path} — {count} subscriber{'s' if count != 1 else ''}"
-    )
-    rich.print(f"\n{header}\n")
+    def __init__(
+        self,
+        app_instance: FastPubSub,
+        app_path: str,
+        columns: list[str],
+        filter_patterns: set[str],
+    ) -> None:
+        """Initialize the SubscriberInspector.
 
-    table = Table()
-    for col in columns:
-        table.add_column(col.replace("_", " ").title())
+        Args:
+            app_instance: The FastPubSub application instance.
+            app_path: The module:attribute path string.
+            columns: Resolved column names to display.
+            filter_patterns: Glob patterns for alias filtering.
+        """
+        self.app_instance = app_instance
+        self.app_path = app_path
+        self.columns = columns
+        self.filter_patterns = filter_patterns
 
-    for record in records:
-        row = record.model_dump(include=set(columns))
-        table.add_row(*[str(row[col]) for col in columns])
+    def inspect(self, output_format: str) -> None:
+        """Run the inspection and print output.
 
-    console = Console()
-    console.print(table)
+        Args:
+            output_format: The output format ('table' or 'json').
+        """
+        records = self._build_records()
 
+        if output_format == "json":
+            return self._print_json(records)
 
-def _format_json(
-    app_path: str,
-    records: list[SubscriberRecord],
-    columns: list[str],
-) -> None:
-    """Print subscribers as JSON.
+        return self._print_table(records)
 
-    Args:
-        app_path: The module:attribute path.
-        records: List of SubscriberRecord to display.
-        columns: Column names to include.
-    """
-    output = {
-        "app": app_path,
-        "version": __version__,
-        "subscribers": [
-            record.model_dump(include=set(columns)) for record in records
-        ],
-    }
-    typer.echo(json.dumps(output, indent=2, default=str))
+    def _build_records(self) -> list[SubscriberRecord]:
+        """Build sorted SubscriberRecord list from the app.
 
+        Returns:
+            A sorted list of SubscriberRecord instances.
+        """
+        subscribers = self.app_instance.broker.router.get_subscribers()
 
-@inspect_app.command(name="subscribers")
-def inspect_subscribers(
-    app: AppArgument,
-    filter_patterns: InspectFilterOption = [],
-    columns: InspectColumnsOption = None,
-    output_format: InspectFormatOption = "table",
-) -> None:
-    """List all subscribers in a FastPubSub application.
+        if self.filter_patterns:
+            selector = SubscriberSelector(patterns=self.filter_patterns)
+            filtered_list = selector.select(subscribers)
+            subscribers = {
+                alias: sub
+                for alias, sub in subscribers.items()
+                if sub in filtered_list
+            }
 
-    Args:
-        app: The application path in module:attribute format.
-        filter_patterns: Glob patterns to filter subscribers by alias.
-        columns: Comma-separated column names, or 'all'.
-        output_format: Output format: 'table' or 'json'.
-    """
-    resolved_columns = resolve_columns(columns)
+        return sorted(
+            [
+                SubscriberRecord.from_subscriber(alias, sub)
+                for alias, sub in subscribers.items()
+            ],
+            key=lambda r: r.alias,
+        )
 
-    fastpubsub_app = import_app(app)
-    subscribers = fastpubsub_app.broker.router.get_subscribers()
+    def _print_table(self, records: list[SubscriberRecord]) -> None:
+        """Print subscribers as a Rich table.
 
-    if filter_patterns:
-        selector = SubscriberSelector(patterns=set(filter_patterns))
-        filtered_list = selector.select(subscribers)
-        subscribers = {
-            alias: sub
-            for alias, sub in subscribers.items()
-            if sub in filtered_list
+        Args:
+            records: List of SubscriberRecord to display.
+        """
+        count = len(records)
+        header = (
+            f"[bold]FastPubSub[/bold] (v{__version__}): "
+            f"{self.app_path} — "
+            f"{count} subscriber{'s' if count != 1 else ''}"
+        )
+        rich.print(f"\n{header}\n")
+
+        table = Table()
+        for col in self.columns:
+            table.add_column(col.replace("_", " ").title())
+
+        for record in records:
+            row = record.model_dump(include=set(self.columns))
+            table.add_row(*[str(row[col]) for col in self.columns])
+
+        console = Console()
+        console.print(table)
+
+    def _print_json(self, records: list[SubscriberRecord]) -> None:
+        """Print subscribers as JSON.
+
+        Args:
+            records: List of SubscriberRecord to display.
+        """
+        output = {
+            "app": self.app_path,
+            "version": __version__,
+            "subscribers": [
+                record.model_dump(include=set(self.columns))
+                for record in records
+            ],
         }
-
-    records = sorted(
-        [
-            SubscriberRecord.from_subscriber(alias, sub)
-            for alias, sub in subscribers.items()
-        ],
-        key=lambda r: r.alias,
-    )
-
-    if output_format == "json":
-        _format_json(app, records, resolved_columns)
-    else:
-        _format_table(app, records, resolved_columns)
+        typer.echo(json.dumps(output, indent=2, default=str))
 
 
 # Future inspect subcommands:

--- a/fastpubsub/cli/inspect.py
+++ b/fastpubsub/cli/inspect.py
@@ -1,0 +1,237 @@
+"""Inspect command for FastPubSub CLI."""
+
+import json
+
+import rich
+import typer
+from pydantic import BaseModel
+from rich.console import Console
+from rich.table import Table
+
+from fastpubsub.__about__ import __version__
+from fastpubsub._internal import SubscriberSelector
+from fastpubsub.cli.options import (
+    AppArgument,
+    InspectColumnsOption,
+    InspectFilterOption,
+    InspectFormatOption,
+)
+from fastpubsub.cli.utils import import_app
+from fastpubsub.pubsub.subscriber import Subscriber
+
+inspect_app = typer.Typer(
+    name="inspect",
+    help="Inspect a FastPubSub application's components.",
+    rich_markup_mode="markdown",
+)
+
+DEFAULT_COLUMNS = ["alias", "project", "topic", "subscription", "handler"]
+
+
+class SubscriberRecord(BaseModel):
+    """Flat representation of a subscriber for inspection output."""
+
+    # Core fields (shown by default)
+    alias: str
+    project: str
+    topic: str
+    subscription: str
+    handler: str
+
+    # Policy fields (available via --columns)
+    ack_deadline: int = 0
+    filter: str = ""
+    ordering: bool = False
+    exactly_once: bool = False
+    max_messages: int = 0
+    retry_min: int = 0
+    retry_max: int = 0
+    dead_letter_topic: str = ""
+    dead_letter_max_attempts: int = 0
+    autocreate: bool = True
+    autoupdate: bool = False
+
+    @classmethod
+    def from_subscriber(
+        cls, alias: str, subscriber: Subscriber
+    ) -> "SubscriberRecord":
+        """Create a SubscriberRecord from an alias and Subscriber.
+
+        Args:
+            alias: The resolved subscriber alias.
+            subscriber: The Subscriber instance.
+
+        Returns:
+            A SubscriberRecord with all fields populated.
+        """
+        return cls(
+            alias=alias,
+            project=subscriber.project_id,
+            topic=subscriber.topic_name,
+            subscription=subscriber.subscription_name,
+            handler=getattr(subscriber.func, "__name__", ""),
+            ack_deadline=subscriber.delivery_policy.ack_deadline_seconds,
+            filter=subscriber.delivery_policy.filter_expression,
+            ordering=subscriber.delivery_policy.enable_message_ordering,
+            exactly_once=(
+                subscriber.delivery_policy.enable_exactly_once_delivery
+            ),
+            max_messages=subscriber.control_flow_policy.max_messages,
+            retry_min=subscriber.retry_policy.min_backoff_delay_secs,
+            retry_max=subscriber.retry_policy.max_backoff_delay_secs,
+            dead_letter_topic=(
+                subscriber.dead_letter_policy.topic_name
+                if subscriber.dead_letter_policy
+                else ""
+            ),
+            dead_letter_max_attempts=(
+                subscriber.dead_letter_policy.max_delivery_attempts
+                if subscriber.dead_letter_policy
+                else 0
+            ),
+            autocreate=subscriber.lifecycle_policy.autocreate,
+            autoupdate=subscriber.lifecycle_policy.autoupdate,
+        )
+
+
+ALL_COLUMNS = list(SubscriberRecord.model_fields.keys())
+
+
+def resolve_columns(columns_arg: str | None) -> list[str]:
+    """Resolve the --columns argument into a list of column names.
+
+    Args:
+        columns_arg: Raw value from the --columns CLI option, or None
+            for defaults.
+
+    Returns:
+        A list of validated column names.
+
+    Raises:
+        typer.BadParameter: If any column name is unknown.
+    """
+    if columns_arg is None:
+        return list(DEFAULT_COLUMNS)
+
+    tokens = [t.strip().lower() for t in columns_arg.split(",")]
+    tokens = [t for t in tokens if t]
+
+    if tokens == ["all"]:
+        return list(ALL_COLUMNS)
+
+    unknown = [t for t in tokens if t not in SubscriberRecord.model_fields]
+    if unknown:
+        available = ", ".join(ALL_COLUMNS)
+        typer.echo(
+            f"Error: Unknown column(s): {', '.join(unknown)}. "
+            f"Available: {available}",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    return tokens
+
+
+def _format_table(
+    app_path: str,
+    records: list[SubscriberRecord],
+    columns: list[str],
+) -> None:
+    """Print subscribers as a Rich table.
+
+    Args:
+        app_path: The module:attribute path for the header.
+        records: List of SubscriberRecord to display.
+        columns: Column names to include.
+    """
+    count = len(records)
+    header = (
+        f"[bold]FastPubSub[/bold] (v{__version__}): "
+        f"{app_path} — {count} subscriber{'s' if count != 1 else ''}"
+    )
+    rich.print(f"\n{header}\n")
+
+    table = Table()
+    for col in columns:
+        table.add_column(col.replace("_", " ").title())
+
+    for record in records:
+        row = record.model_dump(include=set(columns))
+        table.add_row(*[str(row[col]) for col in columns])
+
+    console = Console()
+    console.print(table)
+
+
+def _format_json(
+    app_path: str,
+    records: list[SubscriberRecord],
+    columns: list[str],
+) -> None:
+    """Print subscribers as JSON.
+
+    Args:
+        app_path: The module:attribute path.
+        records: List of SubscriberRecord to display.
+        columns: Column names to include.
+    """
+    output = {
+        "app": app_path,
+        "version": __version__,
+        "subscribers": [
+            record.model_dump(include=set(columns)) for record in records
+        ],
+    }
+    typer.echo(json.dumps(output, indent=2, default=str))
+
+
+@inspect_app.command(name="subscribers")
+def inspect_subscribers(
+    app: AppArgument,
+    filter_patterns: InspectFilterOption = [],
+    columns: InspectColumnsOption = None,
+    output_format: InspectFormatOption = "table",
+) -> None:
+    """List all subscribers in a FastPubSub application.
+
+    Args:
+        app: The application path in module:attribute format.
+        filter_patterns: Glob patterns to filter subscribers by alias.
+        columns: Comma-separated column names, or 'all'.
+        output_format: Output format: 'table' or 'json'.
+    """
+    resolved_columns = resolve_columns(columns)
+
+    fastpubsub_app = import_app(app)
+    subscribers = fastpubsub_app.broker.router.get_subscribers()
+
+    if filter_patterns:
+        selector = SubscriberSelector(patterns=set(filter_patterns))
+        filtered_list = selector.select(subscribers)
+        subscribers = {
+            alias: sub
+            for alias, sub in subscribers.items()
+            if sub in filtered_list
+        }
+
+    records = sorted(
+        [
+            SubscriberRecord.from_subscriber(alias, sub)
+            for alias, sub in subscribers.items()
+        ],
+        key=lambda r: r.alias,
+    )
+
+    if output_format == "json":
+        _format_json(app, records, resolved_columns)
+    else:
+        _format_table(app, records, resolved_columns)
+
+
+# Future inspect subcommands:
+# - inspect topics: list unique topics and their subscribers (fan-out view)
+# - inspect publishers: list registered publishers and target topics
+# - inspect routes: show router hierarchy, prefixes, and nesting
+# - inspect middlewares: show middleware chains per subscriber and global
+# - inspect policies: summary table of retry, DLT, and delivery policies
+# - inspect config: resolved runtime config (project, host, port, env vars)

--- a/fastpubsub/cli/main.py
+++ b/fastpubsub/cli/main.py
@@ -4,7 +4,11 @@ import rich
 import typer
 
 from fastpubsub.__about__ import __version__
-from fastpubsub.cli.inspect import inspect_app
+from fastpubsub.cli.inspect import (
+    SubscriberInspector,
+    inspect_app,
+    resolve_columns,
+)
 from fastpubsub.cli.options import (
     AppArgument,
     AppHostOption,
@@ -18,13 +22,20 @@ from fastpubsub.cli.options import (
     AppServerLogLevelOption,
     AppVersionOption,
     CLIContext,
+    InspectColumnsOption,
+    InspectFilterOption,
+    InspectFormatOption,
 )
 from fastpubsub.cli.runner import (
     AppConfiguration,
     ApplicationRunner,
     ServerConfiguration,
 )
-from fastpubsub.cli.utils import LogLevels, ensure_pubsub_credentials
+from fastpubsub.cli.utils import (
+    LogLevels,
+    ensure_pubsub_credentials,
+    import_app,
+)
 
 app = typer.Typer(
     name="fastpubsub",
@@ -157,6 +168,33 @@ def run(
     application_runner.setup()
     application_runner.validate()
     application_runner.run()
+
+
+@inspect_app.command(name="subscribers")
+def inspect_subscribers(
+    app: AppArgument,
+    filter_patterns: InspectFilterOption = [],
+    columns: InspectColumnsOption = None,
+    output_format: InspectFormatOption = "table",
+) -> None:
+    """List all subscribers in a FastPubSub application.
+
+    Args:
+        app: The application path in module:attribute format.
+        filter_patterns: Glob patterns to filter subscribers by alias.
+        columns: Comma-separated column names, or 'all'.
+        output_format: Output format: 'table' or 'json'.
+    """
+    resolved_columns = resolve_columns(columns)
+    app_instance = import_app(app)
+
+    inspector = SubscriberInspector(
+        app_instance=app_instance,
+        app_path=app,
+        columns=resolved_columns,
+        filter_patterns=set(filter_patterns) if filter_patterns else set(),
+    )
+    inspector.inspect(output_format)
 
 
 @app.command(name="help")

--- a/fastpubsub/cli/main.py
+++ b/fastpubsub/cli/main.py
@@ -4,6 +4,7 @@ import rich
 import typer
 
 from fastpubsub.__about__ import __version__
+from fastpubsub.cli.inspect import inspect_app
 from fastpubsub.cli.options import (
     AppArgument,
     AppHostOption,
@@ -33,6 +34,8 @@ app = typer.Typer(
     invoke_without_command=True,
     rich_markup_mode="markdown",
 )
+
+app.add_typer(inspect_app)
 
 # V2: this command and its subcommands will be released on the future"
 """
@@ -76,8 +79,13 @@ def main(
             "\n[bold]Usage[/bold]: [cyan]fastpubsub [COMMAND] [ARGS]...[/cyan]"
         )
         rich.print("\n[bold]Common Commands:[/bold]")
-        rich.print("  [green]run[/green]    Run a FastPubSub application.")
-        rich.print("  [green]help[/green]   Get detailed help for a command.")
+        rich.print("  [green]run[/green]       Run a FastPubSub application.")
+        rich.print(
+            "  [green]inspect[/green]   Inspect application components."
+        )
+        rich.print(
+            "  [green]help[/green]      Get detailed help for a command."
+        )
         rich.print(
             "\nRun '[cyan]fastpubsub --help[/cyan]' for "
             "a list of all available commands and options."

--- a/fastpubsub/cli/main.py
+++ b/fastpubsub/cli/main.py
@@ -33,6 +33,7 @@ from fastpubsub.cli.runner import (
 )
 from fastpubsub.cli.utils import (
     LogLevels,
+    OutputFormat,
     ensure_pubsub_credentials,
     import_app,
 )
@@ -175,7 +176,7 @@ def inspect_subscribers(
     app: AppArgument,
     filter_patterns: InspectFilterOption = [],
     columns: InspectColumnsOption = None,
-    output_format: InspectFormatOption = "table",
+    output_format: InspectFormatOption = OutputFormat.TABLE,
 ) -> None:
     """List all subscribers in a FastPubSub application.
 

--- a/fastpubsub/cli/options.py
+++ b/fastpubsub/cli/options.py
@@ -127,3 +127,33 @@ AppVersionOption = Annotated[
         help="Show current platform, python and FastPubSub version.",
     ),
 ]
+
+InspectColumnsOption = Annotated[
+    str | None,
+    typer.Option(
+        "-c",
+        "--columns",
+        help="Comma-separated column names to display. "
+        "Use 'all' to show every column including policy fields. "
+        "Default: alias, project, topic, subscription, handler.",
+    ),
+]
+
+InspectFormatOption = Annotated[
+    str,
+    typer.Option(
+        "-f",
+        "--format",
+        help="Output format: 'table' (default) or 'json'.",
+    ),
+]
+
+InspectFilterOption = Annotated[
+    list[str],
+    typer.Option(
+        "--filter",
+        help="Glob pattern to filter subscribers by alias. "
+        "Supports *, ?, and ** wildcards. "
+        "Repeatable: --filter 'orders.*' --filter 'payments.*'.",
+    ),
+]

--- a/fastpubsub/cli/options.py
+++ b/fastpubsub/cli/options.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import typer
 
-from fastpubsub.cli.utils import LogLevels
+from fastpubsub.cli.utils import LogLevels, OutputFormat
 
 CLIContext = typer.Context
 
@@ -140,10 +140,11 @@ InspectColumnsOption = Annotated[
 ]
 
 InspectFormatOption = Annotated[
-    str,
+    OutputFormat,
     typer.Option(
         "-f",
         "--format",
+        case_sensitive=False,
         help="Output format: 'table' (default) or 'json'.",
     ),
 ]

--- a/fastpubsub/cli/runner.py
+++ b/fastpubsub/cli/runner.py
@@ -67,19 +67,13 @@ class ApplicationRunner:
 
     def validate(self) -> None:
         """Validates a FastPubSub application."""
-        from fastpubsub.applications import FastPubSub
-        from fastpubsub.exceptions import FastPubSubCLIException
+        from fastpubsub.cli.utils import import_app
 
         posix_path = self._translate_pypath_to_posix(
             pypath=self.app_config.app
         )
         self._resolve_application_posix_path(posix_path=posix_path)
-
-        app = uvicorn.importer.import_from_string(self.app_config.app)
-        if not app or not isinstance(app, FastPubSub):
-            raise FastPubSubCLIException(
-                f"The app {self.app_config.app} is not a {FastPubSub} instance"
-            )
+        import_app(self.app_config.app)
 
     def run(self) -> None:
         """Runs a FastPubSub application."""

--- a/fastpubsub/cli/utils.py
+++ b/fastpubsub/cli/utils.py
@@ -1,9 +1,15 @@
 """Command-line interface utilities."""
 
+from __future__ import annotations
+
 import os
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from fastpubsub.exceptions import FastPubSubCLIException
+
+if TYPE_CHECKING:
+    from fastpubsub.applications import FastPubSub
 
 
 class LogLevels(StrEnum):
@@ -27,3 +33,51 @@ def ensure_pubsub_credentials() -> None:
             "environment variables for authentication: "
             "(GOOGLE_APPLICATION_CREDENTIALS, PUBSUB_EMULATOR_HOST)"
         )
+
+
+def import_app(app_path: str) -> FastPubSub:
+    """Import and validate a FastPubSub application from a module path.
+
+    Args:
+        app_path: The application path in "module:attribute" format.
+
+    Returns:
+        The FastPubSub application instance.
+
+    Raises:
+        FastPubSubCLIException: If the import fails or the object
+            is not a FastPubSub instance.
+    """
+    from fastpubsub.applications import FastPubSub as _FastPubSub
+
+    if ":" not in app_path:
+        raise FastPubSubCLIException(
+            f"Invalid app path '{app_path}'. "
+            "Expected format: module:attribute "
+            "(e.g., myapp.main:app)"
+        )
+
+    module_str, _ = app_path.rsplit(":", 1)
+
+    try:
+        import uvicorn.importer
+
+        app = uvicorn.importer.import_from_string(app_path)
+    except ModuleNotFoundError as exc:
+        raise FastPubSubCLIException(
+            f"Could not find module '{module_str}'. "
+            "Check the module path and ensure it is "
+            "importable from the current directory."
+        ) from exc
+    except ImportError as exc:
+        raise FastPubSubCLIException(
+            f"Failed to import '{app_path}': {exc}"
+        ) from exc
+
+    if not isinstance(app, _FastPubSub):
+        raise FastPubSubCLIException(
+            f"The object at '{app_path}' is not a "
+            f"FastPubSub instance (got {type(app).__name__})."
+        )
+
+    return app

--- a/fastpubsub/cli/utils.py
+++ b/fastpubsub/cli/utils.py
@@ -48,7 +48,7 @@ def import_app(app_path: str) -> FastPubSub:
         FastPubSubCLIException: If the import fails or the object
             is not a FastPubSub instance.
     """
-    from fastpubsub.applications import FastPubSub as _FastPubSub
+    from fastpubsub.applications import FastPubSub
 
     if ":" not in app_path:
         raise FastPubSubCLIException(
@@ -74,7 +74,7 @@ def import_app(app_path: str) -> FastPubSub:
             f"Failed to import '{app_path}': {exc}"
         ) from exc
 
-    if not isinstance(app, _FastPubSub):
+    if not isinstance(app, FastPubSub):
         raise FastPubSubCLIException(
             f"The object at '{app_path}' is not a "
             f"FastPubSub instance (got {type(app).__name__})."

--- a/fastpubsub/cli/utils.py
+++ b/fastpubsub/cli/utils.py
@@ -23,6 +23,13 @@ class LogLevels(StrEnum):
     DEBUG = "debug"
 
 
+class OutputFormat(StrEnum):
+    """A class to represent output formats."""
+
+    TABLE = "table"
+    JSON = "json"
+
+
 def ensure_pubsub_credentials() -> None:
     """Ensures that the Pub/Sub credentials are set."""
     credentials = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")

--- a/fastpubsub/router.py
+++ b/fastpubsub/router.py
@@ -329,12 +329,13 @@ class PubSubRouter:
         if wrapper_middleware not in self.middlewares:
             self.middlewares.append(wrapper_middleware)
 
-    def _get_subscribers(self) -> dict[str, Subscriber]:
+    def get_subscribers(self) -> dict[str, Subscriber]:
+        """Return all subscribers from this router and its nested routers."""
         subscribers: dict[str, Subscriber] = {}
         subscribers.update(self.subscribers)
         router: PubSubRouter
         for router in self.routers:
-            router_subscribers = router._get_subscribers()
+            router_subscribers = router.get_subscribers()
             for alias, new_subscriber in router.subscribers.items():
                 if alias in subscribers:
                     existing_subscriber = subscribers[alias]

--- a/fastpubsub/testing.py
+++ b/fastpubsub/testing.py
@@ -533,7 +533,7 @@ class PubSubTestClient:
             )
         )
 
-        subscribers = self.broker.router._get_subscribers()
+        subscribers = self.broker.router.get_subscribers()
         for subscriber in subscribers.values():
             if subscriber.topic_name != topic_name:
                 continue

--- a/tests/docs/basic_usage/test_cli_wildcards.py
+++ b/tests/docs/basic_usage/test_cli_wildcards.py
@@ -13,26 +13,26 @@ class TestCLIWildcardSnippet:
     """Verify the wildcard snippet registers expected aliases."""
 
     def test_all_aliases_registered(self) -> None:
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
         assert "orders.process" in subscribers
         assert "orders.validate" in subscribers
         assert "orders.notify" in subscribers
         assert "payments.process" in subscribers
 
     def test_wildcard_orders_star(self) -> None:
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
         selector = SubscriberSelector(patterns={"orders.*"})
         result = selector.select(subscribers)
         assert len(result) == 3
 
     def test_wildcard_star_process(self) -> None:
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
         selector = SubscriberSelector(patterns={"*.process"})
         result = selector.select(subscribers)
         assert len(result) == 2
 
     def test_wildcard_double_star_process(self) -> None:
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
         selector = SubscriberSelector(patterns={"**.process"})
         result = selector.select(subscribers)
         assert len(result) == 2

--- a/tests/docs/basic_usage/test_cross_project_publish.py
+++ b/tests/docs/basic_usage/test_cross_project_publish.py
@@ -32,7 +32,7 @@ class TestCrossProjectPublish:
         )
         assert results == []
 
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
         assert (
             subscribers["shared-events-handler"].project_id
             == "other-project-id"

--- a/tests/docs/basic_usage/test_inspect_basic.py
+++ b/tests/docs/basic_usage/test_inspect_basic.py
@@ -1,0 +1,41 @@
+"""Tests for inspect basic snippet."""
+
+from __future__ import annotations
+
+import pytest
+
+from docs.snippets.basic_usage.e9_01_inspect_basic import broker
+
+
+@pytest.mark.docs
+class TestInspectBasicSnippet:
+    """Verify the inspect basic snippet registers expected aliases."""
+
+    def test_all_aliases_registered(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        assert "process-orders" in subscribers
+        assert "charge-payments" in subscribers
+        assert "send-notifications" in subscribers
+
+    def test_subscriber_count(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        assert len(subscribers) == 3
+
+    def test_process_orders_has_dead_letter(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        sub = subscribers["process-orders"]
+        assert sub.dead_letter_policy is not None
+        assert sub.dead_letter_policy.topic_name == "order-events-dlq"
+
+    def test_charge_payments_has_exactly_once(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        sub = subscribers["charge-payments"]
+        assert sub.delivery_policy.enable_exactly_once_delivery is True
+
+    def test_send_notifications_has_filter(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        sub = subscribers["send-notifications"]
+        assert (
+            sub.delivery_policy.filter_expression
+            == 'attributes.channel = "email"'
+        )

--- a/tests/docs/basic_usage/test_inspect_routers.py
+++ b/tests/docs/basic_usage/test_inspect_routers.py
@@ -1,0 +1,34 @@
+"""Tests for inspect routers snippet."""
+
+from __future__ import annotations
+
+import pytest
+
+from docs.snippets.basic_usage.e9_02_inspect_routers import broker
+
+
+@pytest.mark.docs
+class TestInspectRoutersSnippet:
+    """Verify the inspect routers snippet registers expected aliases."""
+
+    def test_all_aliases_registered(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        assert "platform.orders.fulfill" in subscribers
+        assert "platform.orders.invoice" in subscribers
+        assert "platform.analytics.track" in subscribers
+
+    def test_subscriber_count(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        assert len(subscribers) == 3
+
+    def test_track_uses_different_project(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        sub = subscribers["platform.analytics.track"]
+        assert sub.project_id == "analytics-warehouse"
+
+    def test_order_subscribers_share_topic(self) -> None:
+        subscribers = broker.router.get_subscribers()
+        fulfill = subscribers["platform.orders.fulfill"]
+        invoice = subscribers["platform.orders.invoice"]
+        assert fulfill.topic_name == "order-events"
+        assert invoice.topic_name == "order-events"

--- a/tests/docs/routers/test_nested_routers_financial.py
+++ b/tests/docs/routers/test_nested_routers_financial.py
@@ -18,7 +18,7 @@ class TestRoutersNestedRoutersFinancial:
 
             published_messages = client.get_published_messages()
             processed_results = client.get_results()
-            subscribers_alias = set(broker.router._get_subscribers())
+            subscribers_alias = set(broker.router.get_subscribers())
 
         assert len(subscribers_alias) == 3
         assert len(published_messages) == 3

--- a/tests/docs/routers/test_prefix_resolution_fails.py
+++ b/tests/docs/routers/test_prefix_resolution_fails.py
@@ -21,7 +21,7 @@ class TestAliasResolutionFailed:
     @pytest.mark.docs
     def test_alias_conflict_raises_error(self, broker: PubSubBroker) -> None:
         with pytest.raises(FastPubSubException) as exc_info:
-            broker.router._get_subscribers()
+            broker.router.get_subscribers()
 
         error_message = str(exc_info.value)
         assert "test-alias-abc" in error_message

--- a/tests/docs/routers/test_router_middlewares.py
+++ b/tests/docs/routers/test_router_middlewares.py
@@ -36,7 +36,7 @@ class TestRoutersRouterMiddlewares:
     def test_router_middleware_registration_propagates_into_subscribers(
         self,
     ) -> None:
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
 
         subscriber_created = subscribers["users.created"]
         subscriber_deleted = subscribers["users.deleted"]

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -91,7 +91,7 @@ class TestPubSubBroker:
         os.environ["FASTPUBSUB_SUBSCRIBERS"] = selected_subscribers
         try:
             mock_router = MagicMock()
-            mock_router._get_subscribers = MagicMock(
+            mock_router.get_subscribers = MagicMock(
                 return_value={"a": "a", "b": "b"}
             )
             broker.router = mock_router
@@ -127,7 +127,7 @@ class TestPubSubBroker:
         try:
             os.environ["FASTPUBSUB_SUBSCRIBERS"] = selected_subscribers
             broker.router = MagicMock()
-            broker.router._get_subscribers.return_value = {
+            broker.router.get_subscribers.return_value = {
                 "a.x": "ax",
                 "a.y": "ay",
                 "b.x": "bx",

--- a/tests/unit/test_cli_inspect.py
+++ b/tests/unit/test_cli_inspect.py
@@ -1,64 +1,62 @@
 """Tests for the inspect CLI command."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
+from fastpubsub.__about__ import __version__
 from fastpubsub.applications import FastPubSub
 from fastpubsub.broker import PubSubBroker
+from fastpubsub.cli.inspect import (
+    ALL_COLUMNS,
+    SubscriberRecord,
+    resolve_columns,
+)
 from fastpubsub.cli.main import app
 from fastpubsub.datastructures import Message
+from fastpubsub.exceptions import FastPubSubCLIException
 
 runner = CliRunner()
 
 
-def _build_test_app() -> FastPubSub:
-    """Build a FastPubSub app with test subscribers."""
-    broker = PubSubBroker(project_id="test-project")
-
-    @broker.subscriber(
-        alias="handler_b",
-        topic_name="topic-b",
-        subscription_name="sub-b",
-    )
-    async def handler_b(message: Message) -> None:
-        pass
-
-    @broker.subscriber(
-        alias="handler_a",
-        topic_name="topic-a",
-        subscription_name="sub-a",
-        dead_letter_topic="dlt-topic",
-        max_delivery_attempts=10,
-        ack_deadline_seconds=30,
-        filter_expression='attributes.type = "order"',
-        enable_message_ordering=True,
-        enable_exactly_once_delivery=True,
-        max_messages=500,
-        min_backoff_delay_secs=5,
-        max_backoff_delay_secs=300,
-        autocreate=False,
-        autoupdate=True,
-    )
-    async def handler_a(message: Message) -> None:
-        pass
-
-    return FastPubSub(broker=broker)
-
-
-def _build_empty_app() -> FastPubSub:
-    """Build a FastPubSub app with no subscribers."""
-    broker = PubSubBroker(project_id="test-project")
-    return FastPubSub(broker=broker)
-
-
 class TestSubscriberRecord:
-    def test_from_subscriber_core_fields(self):
-        from fastpubsub.cli.inspect import SubscriberRecord
+    @pytest.fixture()
+    def test_app(self) -> FastPubSub:
+        """Build a FastPubSub app with test subscribers."""
+        broker = PubSubBroker(project_id="test-project")
 
-        test_app = _build_test_app()
+        @broker.subscriber(
+            alias="handler_b",
+            topic_name="topic-b",
+            subscription_name="sub-b",
+        )
+        async def handler_b(message: Message) -> None:
+            pass
+
+        @broker.subscriber(
+            alias="handler_a",
+            topic_name="topic-a",
+            subscription_name="sub-a",
+            dead_letter_topic="dlt-topic",
+            max_delivery_attempts=10,
+            ack_deadline_seconds=30,
+            filter_expression='attributes.type = "order"',
+            enable_message_ordering=True,
+            enable_exactly_once_delivery=True,
+            max_messages=500,
+            min_backoff_delay_secs=5,
+            max_backoff_delay_secs=300,
+            autocreate=False,
+            autoupdate=True,
+        )
+        async def handler_a(message: Message) -> None:
+            pass
+
+        return FastPubSub(broker=broker)
+
+    def test_from_subscriber_core_fields(self, test_app: FastPubSub):
         subscribers = test_app.broker.router.get_subscribers()
         record = SubscriberRecord.from_subscriber(
             "handler_a", subscribers["handler_a"]
@@ -69,10 +67,7 @@ class TestSubscriberRecord:
         assert record.subscription == "sub-a"
         assert record.handler == "handler_a"
 
-    def test_from_subscriber_policy_fields(self):
-        from fastpubsub.cli.inspect import SubscriberRecord
-
-        test_app = _build_test_app()
+    def test_from_subscriber_policy_fields(self, test_app: FastPubSub):
         subscribers = test_app.broker.router.get_subscribers()
         record = SubscriberRecord.from_subscriber(
             "handler_a", subscribers["handler_a"]
@@ -89,10 +84,7 @@ class TestSubscriberRecord:
         assert record.autocreate is False
         assert record.autoupdate is True
 
-    def test_from_subscriber_no_dead_letter(self):
-        from fastpubsub.cli.inspect import SubscriberRecord
-
-        test_app = _build_test_app()
+    def test_from_subscriber_no_dead_letter(self, test_app: FastPubSub):
         subscribers = test_app.broker.router.get_subscribers()
         record = SubscriberRecord.from_subscriber(
             "handler_b", subscribers["handler_b"]
@@ -100,10 +92,7 @@ class TestSubscriberRecord:
         assert record.dead_letter_topic == ""
         assert record.dead_letter_max_attempts == 0
 
-    def test_model_dump_with_include(self):
-        from fastpubsub.cli.inspect import SubscriberRecord
-
-        test_app = _build_test_app()
+    def test_model_dump_with_include(self, test_app: FastPubSub):
         subscribers = test_app.broker.router.get_subscribers()
         record = SubscriberRecord.from_subscriber(
             "handler_a", subscribers["handler_a"]
@@ -114,52 +103,65 @@ class TestSubscriberRecord:
 
 class TestResolveColumns:
     def test_default_columns(self):
-        from fastpubsub.cli.inspect import resolve_columns
-
         cols = resolve_columns(None)
-        assert cols == ["alias", "project", "topic", "subscription", "handler"]
+        assert cols == [
+            "alias",
+            "project",
+            "topic",
+            "subscription",
+            "handler",
+        ]
 
     def test_columns_all(self):
-        from fastpubsub.cli.inspect import (
-            ALL_COLUMNS,
-            resolve_columns,
-        )
-
         cols = resolve_columns("all")
         assert cols == ALL_COLUMNS
 
     def test_columns_all_case_insensitive(self):
-        from fastpubsub.cli.inspect import (
-            ALL_COLUMNS,
-            resolve_columns,
-        )
-
         cols = resolve_columns("ALL")
         assert cols == ALL_COLUMNS
 
     def test_specific_columns(self):
-        from fastpubsub.cli.inspect import resolve_columns
-
         cols = resolve_columns("alias,topic")
         assert cols == ["alias", "topic"]
 
     def test_columns_whitespace_tolerant(self):
-        from fastpubsub.cli.inspect import resolve_columns
-
         cols = resolve_columns(" Alias , Topic ")
         assert cols == ["alias", "topic"]
 
     def test_unknown_column_raises(self):
-        from fastpubsub.cli.inspect import resolve_columns
-
-        with pytest.raises(SystemExit):
+        with pytest.raises(FastPubSubCLIException):
             resolve_columns("alias,nonexistent")
 
 
 class TestInspectSubscribersFilter:
+    @pytest.fixture()
+    def test_app(self) -> FastPubSub:
+        """Build a FastPubSub app with test subscribers."""
+        broker = PubSubBroker(project_id="test-project")
+
+        @broker.subscriber(
+            alias="handler_b",
+            topic_name="topic-b",
+            subscription_name="sub-b",
+        )
+        async def handler_b(message: Message) -> None:
+            pass
+
+        @broker.subscriber(
+            alias="handler_a",
+            topic_name="topic-a",
+            subscription_name="sub-a",
+        )
+        async def handler_a(message: Message) -> None:
+            pass
+
+        return FastPubSub(broker=broker)
+
     @patch("fastpubsub.cli.main.import_app")
-    def test_filter_exact_alias(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_filter_exact_alias(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -175,8 +177,10 @@ class TestInspectSubscribersFilter:
         assert "handler_b" not in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_filter_glob_pattern(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_filter_glob_pattern(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -192,8 +196,10 @@ class TestInspectSubscribersFilter:
         assert "handler_b" in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_filter_multiple_patterns(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_filter_multiple_patterns(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -211,8 +217,10 @@ class TestInspectSubscribersFilter:
         assert "handler_b" in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_filter_no_matches(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_filter_no_matches(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -227,8 +235,10 @@ class TestInspectSubscribersFilter:
         assert "0 subscribers" in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_filter_with_json_format(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_filter_with_json_format(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -248,9 +258,51 @@ class TestInspectSubscribersFilter:
 
 
 class TestInspectSubscribersTable:
+    @pytest.fixture()
+    def test_app(self) -> FastPubSub:
+        """Build a FastPubSub app with test subscribers."""
+        broker = PubSubBroker(project_id="test-project")
+
+        @broker.subscriber(
+            alias="handler_b",
+            topic_name="topic-b",
+            subscription_name="sub-b",
+        )
+        async def handler_b(message: Message) -> None:
+            pass
+
+        @broker.subscriber(
+            alias="handler_a",
+            topic_name="topic-a",
+            subscription_name="sub-a",
+            dead_letter_topic="dlt-topic",
+            max_delivery_attempts=10,
+            ack_deadline_seconds=30,
+            filter_expression='attributes.type = "order"',
+            enable_message_ordering=True,
+            enable_exactly_once_delivery=True,
+            max_messages=500,
+            min_backoff_delay_secs=5,
+            max_backoff_delay_secs=300,
+            autocreate=False,
+            autoupdate=True,
+        )
+        async def handler_a(message: Message) -> None:
+            pass
+
+        return FastPubSub(broker=broker)
+
+    @pytest.fixture()
+    def empty_app(self) -> FastPubSub:
+        """Build a FastPubSub app with no subscribers."""
+        broker = PubSubBroker(project_id="test-project")
+        return FastPubSub(broker=broker)
+
     @patch("fastpubsub.cli.main.import_app")
-    def test_default_table_output(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_default_table_output(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
         assert result.exit_code == 0
         assert "handler_a" in result.stdout
@@ -260,8 +312,10 @@ class TestInspectSubscribersTable:
         assert "topic-b" in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_sorted_by_alias(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_sorted_by_alias(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
         assert result.exit_code == 0
         pos_a = result.stdout.index("handler_a")
@@ -269,8 +323,10 @@ class TestInspectSubscribersTable:
         assert pos_a < pos_b
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_columns_alias_topic_only(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_columns_alias_topic_only(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -288,8 +344,8 @@ class TestInspectSubscribersTable:
         assert "sub-a" not in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_columns_all(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_columns_all(self, mock_import: MagicMock, test_app: FastPubSub):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -304,16 +360,16 @@ class TestInspectSubscribersTable:
         )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
-        from fastpubsub.cli.inspect import ALL_COLUMNS
-
         for sub in data["subscribers"]:
             assert set(sub.keys()) == set(ALL_COLUMNS)
         aliases = [s["alias"] for s in data["subscribers"]]
         assert "handler_a" in aliases
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_columns_case_insensitive(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_columns_case_insensitive(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -329,8 +385,10 @@ class TestInspectSubscribersTable:
         assert "topic-a" in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_unknown_column_error(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_unknown_column_error(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -342,29 +400,61 @@ class TestInspectSubscribersTable:
             ],
         )
         assert result.exit_code != 0
-        assert "nonexistent" in result.output
+        assert isinstance(result.exception, FastPubSubCLIException)
+        assert "nonexistent" in str(result.exception)
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_empty_app_table(self, mock_import):
-        mock_import.return_value = _build_empty_app()
+    def test_empty_app_table(
+        self, mock_import: MagicMock, empty_app: FastPubSub
+    ):
+        mock_import.return_value = empty_app
         result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
         assert result.exit_code == 0
         assert "0 subscribers" in result.stdout
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_header_shows_version(self, mock_import):
-        from fastpubsub.__about__ import __version__
-
-        mock_import.return_value = _build_test_app()
+    def test_header_shows_version(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
         assert result.exit_code == 0
         assert __version__ in result.stdout
 
 
 class TestInspectSubscribersJson:
+    @pytest.fixture()
+    def test_app(self) -> FastPubSub:
+        """Build a FastPubSub app with test subscribers."""
+        broker = PubSubBroker(project_id="test-project")
+
+        @broker.subscriber(
+            alias="handler_b",
+            topic_name="topic-b",
+            subscription_name="sub-b",
+        )
+        async def handler_b(message: Message) -> None:
+            pass
+
+        @broker.subscriber(
+            alias="handler_a",
+            topic_name="topic-a",
+            subscription_name="sub-a",
+        )
+        async def handler_a(message: Message) -> None:
+            pass
+
+        return FastPubSub(broker=broker)
+
+    @pytest.fixture()
+    def empty_app(self) -> FastPubSub:
+        """Build a FastPubSub app with no subscribers."""
+        broker = PubSubBroker(project_id="test-project")
+        return FastPubSub(broker=broker)
+
     @patch("fastpubsub.cli.main.import_app")
-    def test_json_output(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_json_output(self, mock_import: MagicMock, test_app: FastPubSub):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -382,8 +472,10 @@ class TestInspectSubscribersJson:
         assert len(data["subscribers"]) == 2
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_json_sorted_by_alias(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_json_sorted_by_alias(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -399,8 +491,10 @@ class TestInspectSubscribersJson:
         assert aliases == sorted(aliases)
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_json_with_columns(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_json_with_columns(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -418,8 +512,10 @@ class TestInspectSubscribersJson:
             assert set(sub.keys()) == {"alias", "topic"}
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_json_columns_all(self, mock_import):
-        mock_import.return_value = _build_test_app()
+    def test_json_columns_all(
+        self, mock_import: MagicMock, test_app: FastPubSub
+    ):
+        mock_import.return_value = test_app
         result = runner.invoke(
             app,
             [
@@ -433,14 +529,14 @@ class TestInspectSubscribersJson:
             ],
         )
         data = json.loads(result.stdout)
-        from fastpubsub.cli.inspect import ALL_COLUMNS
-
         for sub in data["subscribers"]:
             assert set(sub.keys()) == set(ALL_COLUMNS)
 
     @patch("fastpubsub.cli.main.import_app")
-    def test_json_empty_app(self, mock_import):
-        mock_import.return_value = _build_empty_app()
+    def test_json_empty_app(
+        self, mock_import: MagicMock, empty_app: FastPubSub
+    ):
+        mock_import.return_value = empty_app
         result = runner.invoke(
             app,
             [

--- a/tests/unit/test_cli_inspect.py
+++ b/tests/unit/test_cli_inspect.py
@@ -157,7 +157,7 @@ class TestResolveColumns:
 
 
 class TestInspectSubscribersFilter:
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_filter_exact_alias(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -174,7 +174,7 @@ class TestInspectSubscribersFilter:
         assert "handler_a" in result.stdout
         assert "handler_b" not in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_filter_glob_pattern(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -191,7 +191,7 @@ class TestInspectSubscribersFilter:
         assert "handler_a" in result.stdout
         assert "handler_b" in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_filter_multiple_patterns(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -210,7 +210,7 @@ class TestInspectSubscribersFilter:
         assert "handler_a" in result.stdout
         assert "handler_b" in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_filter_no_matches(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -226,7 +226,7 @@ class TestInspectSubscribersFilter:
         assert result.exit_code == 0
         assert "0 subscribers" in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_filter_with_json_format(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -248,7 +248,7 @@ class TestInspectSubscribersFilter:
 
 
 class TestInspectSubscribersTable:
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_default_table_output(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
@@ -259,7 +259,7 @@ class TestInspectSubscribersTable:
         assert "topic-a" in result.stdout
         assert "topic-b" in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_sorted_by_alias(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
@@ -268,7 +268,7 @@ class TestInspectSubscribersTable:
         pos_b = result.stdout.index("handler_b")
         assert pos_a < pos_b
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_columns_alias_topic_only(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -287,7 +287,7 @@ class TestInspectSubscribersTable:
         # subscription column should NOT appear
         assert "sub-a" not in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_columns_all(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -311,7 +311,7 @@ class TestInspectSubscribersTable:
         aliases = [s["alias"] for s in data["subscribers"]]
         assert "handler_a" in aliases
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_columns_case_insensitive(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -328,7 +328,7 @@ class TestInspectSubscribersTable:
         assert "handler_a" in result.stdout
         assert "topic-a" in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_unknown_column_error(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -344,14 +344,14 @@ class TestInspectSubscribersTable:
         assert result.exit_code != 0
         assert "nonexistent" in result.output
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_empty_app_table(self, mock_import):
         mock_import.return_value = _build_empty_app()
         result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
         assert result.exit_code == 0
         assert "0 subscribers" in result.stdout
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_header_shows_version(self, mock_import):
         from fastpubsub.__about__ import __version__
 
@@ -362,7 +362,7 @@ class TestInspectSubscribersTable:
 
 
 class TestInspectSubscribersJson:
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_json_output(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -381,7 +381,7 @@ class TestInspectSubscribersJson:
         assert "version" in data
         assert len(data["subscribers"]) == 2
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_json_sorted_by_alias(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -398,7 +398,7 @@ class TestInspectSubscribersJson:
         aliases = [s["alias"] for s in data["subscribers"]]
         assert aliases == sorted(aliases)
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_json_with_columns(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -417,7 +417,7 @@ class TestInspectSubscribersJson:
         for sub in data["subscribers"]:
             assert set(sub.keys()) == {"alias", "topic"}
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_json_columns_all(self, mock_import):
         mock_import.return_value = _build_test_app()
         result = runner.invoke(
@@ -438,7 +438,7 @@ class TestInspectSubscribersJson:
         for sub in data["subscribers"]:
             assert set(sub.keys()) == set(ALL_COLUMNS)
 
-    @patch("fastpubsub.cli.inspect.import_app")
+    @patch("fastpubsub.cli.main.import_app")
     def test_json_empty_app(self, mock_import):
         mock_import.return_value = _build_empty_app()
         result = runner.invoke(

--- a/tests/unit/test_cli_inspect.py
+++ b/tests/unit/test_cli_inspect.py
@@ -1,0 +1,152 @@
+"""Tests for the inspect CLI command."""
+
+import pytest
+from typer.testing import CliRunner
+
+from fastpubsub.applications import FastPubSub
+from fastpubsub.broker import PubSubBroker
+from fastpubsub.datastructures import Message
+
+runner = CliRunner()
+
+
+def _build_test_app() -> FastPubSub:
+    """Build a FastPubSub app with test subscribers."""
+    broker = PubSubBroker(project_id="test-project")
+
+    @broker.subscriber(
+        alias="handler_b",
+        topic_name="topic-b",
+        subscription_name="sub-b",
+    )
+    async def handler_b(message: Message) -> None:
+        pass
+
+    @broker.subscriber(
+        alias="handler_a",
+        topic_name="topic-a",
+        subscription_name="sub-a",
+        dead_letter_topic="dlt-topic",
+        max_delivery_attempts=10,
+        ack_deadline_seconds=30,
+        filter_expression='attributes.type = "order"',
+        enable_message_ordering=True,
+        enable_exactly_once_delivery=True,
+        max_messages=500,
+        min_backoff_delay_secs=5,
+        max_backoff_delay_secs=300,
+        autocreate=False,
+        autoupdate=True,
+    )
+    async def handler_a(message: Message) -> None:
+        pass
+
+    return FastPubSub(broker=broker)
+
+
+def _build_empty_app() -> FastPubSub:
+    """Build a FastPubSub app with no subscribers."""
+    broker = PubSubBroker(project_id="test-project")
+    return FastPubSub(broker=broker)
+
+
+class TestSubscriberRecord:
+    def test_from_subscriber_core_fields(self):
+        from fastpubsub.cli.inspect import SubscriberRecord
+
+        test_app = _build_test_app()
+        subscribers = test_app.broker.router.get_subscribers()
+        record = SubscriberRecord.from_subscriber(
+            "handler_a", subscribers["handler_a"]
+        )
+        assert record.alias == "handler_a"
+        assert record.project == "test-project"
+        assert record.topic == "topic-a"
+        assert record.subscription == "sub-a"
+        assert record.handler == "handler_a"
+
+    def test_from_subscriber_policy_fields(self):
+        from fastpubsub.cli.inspect import SubscriberRecord
+
+        test_app = _build_test_app()
+        subscribers = test_app.broker.router.get_subscribers()
+        record = SubscriberRecord.from_subscriber(
+            "handler_a", subscribers["handler_a"]
+        )
+        assert record.ack_deadline == 30
+        assert record.filter == 'attributes.type = "order"'
+        assert record.ordering is True
+        assert record.exactly_once is True
+        assert record.max_messages == 500
+        assert record.retry_min == 5
+        assert record.retry_max == 300
+        assert record.dead_letter_topic == "dlt-topic"
+        assert record.dead_letter_max_attempts == 10
+        assert record.autocreate is False
+        assert record.autoupdate is True
+
+    def test_from_subscriber_no_dead_letter(self):
+        from fastpubsub.cli.inspect import SubscriberRecord
+
+        test_app = _build_test_app()
+        subscribers = test_app.broker.router.get_subscribers()
+        record = SubscriberRecord.from_subscriber(
+            "handler_b", subscribers["handler_b"]
+        )
+        assert record.dead_letter_topic == ""
+        assert record.dead_letter_max_attempts == 0
+
+    def test_model_dump_with_include(self):
+        from fastpubsub.cli.inspect import SubscriberRecord
+
+        test_app = _build_test_app()
+        subscribers = test_app.broker.router.get_subscribers()
+        record = SubscriberRecord.from_subscriber(
+            "handler_a", subscribers["handler_a"]
+        )
+        row = record.model_dump(include={"alias", "topic"})
+        assert row == {"alias": "handler_a", "topic": "topic-a"}
+
+
+class TestResolveColumns:
+    def test_default_columns(self):
+        from fastpubsub.cli.inspect import resolve_columns
+
+        cols = resolve_columns(None)
+        assert cols == ["alias", "project", "topic", "subscription", "handler"]
+
+    def test_columns_all(self):
+        from fastpubsub.cli.inspect import (
+            ALL_COLUMNS,
+            resolve_columns,
+        )
+
+        cols = resolve_columns("all")
+        assert cols == ALL_COLUMNS
+
+    def test_columns_all_case_insensitive(self):
+        from fastpubsub.cli.inspect import (
+            ALL_COLUMNS,
+            resolve_columns,
+        )
+
+        cols = resolve_columns("ALL")
+        assert cols == ALL_COLUMNS
+
+    def test_specific_columns(self):
+        from fastpubsub.cli.inspect import resolve_columns
+
+        cols = resolve_columns("alias,topic")
+        assert cols == ["alias", "topic"]
+
+    def test_columns_whitespace_tolerant(self):
+        from fastpubsub.cli.inspect import resolve_columns
+
+        cols = resolve_columns(" Alias , Topic ")
+        assert cols == ["alias", "topic"]
+
+    def test_unknown_column_raises(self):
+        from fastpubsub.cli.inspect import resolve_columns
+
+        with pytest.raises(SystemExit):
+            resolve_columns("alias,nonexistent")

--- a/tests/unit/test_cli_inspect.py
+++ b/tests/unit/test_cli_inspect.py
@@ -1,10 +1,14 @@
 """Tests for the inspect CLI command."""
 
+import json
+from unittest.mock import patch
+
 import pytest
 from typer.testing import CliRunner
 
 from fastpubsub.applications import FastPubSub
 from fastpubsub.broker import PubSubBroker
+from fastpubsub.cli.main import app
 from fastpubsub.datastructures import Message
 
 runner = CliRunner()
@@ -150,3 +154,302 @@ class TestResolveColumns:
 
         with pytest.raises(SystemExit):
             resolve_columns("alias,nonexistent")
+
+
+class TestInspectSubscribersFilter:
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_filter_exact_alias(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--filter",
+                "handler_a",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "handler_a" in result.stdout
+        assert "handler_b" not in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_filter_glob_pattern(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--filter",
+                "handler_*",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "handler_a" in result.stdout
+        assert "handler_b" in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_filter_multiple_patterns(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--filter",
+                "handler_a",
+                "--filter",
+                "handler_b",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "handler_a" in result.stdout
+        assert "handler_b" in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_filter_no_matches(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--filter",
+                "nonexistent_*",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "0 subscribers" in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_filter_with_json_format(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--filter",
+                "handler_a",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data["subscribers"]) == 1
+        assert data["subscribers"][0]["alias"] == "handler_a"
+
+
+class TestInspectSubscribersTable:
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_default_table_output(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
+        assert result.exit_code == 0
+        assert "handler_a" in result.stdout
+        assert "handler_b" in result.stdout
+        assert "test-project" in result.stdout
+        assert "topic-a" in result.stdout
+        assert "topic-b" in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_sorted_by_alias(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
+        assert result.exit_code == 0
+        pos_a = result.stdout.index("handler_a")
+        pos_b = result.stdout.index("handler_b")
+        assert pos_a < pos_b
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_columns_alias_topic_only(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--columns",
+                "alias,topic",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "handler_a" in result.stdout
+        assert "topic-a" in result.stdout
+        # subscription column should NOT appear
+        assert "sub-a" not in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_columns_all(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--columns",
+                "all",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        from fastpubsub.cli.inspect import ALL_COLUMNS
+
+        for sub in data["subscribers"]:
+            assert set(sub.keys()) == set(ALL_COLUMNS)
+        aliases = [s["alias"] for s in data["subscribers"]]
+        assert "handler_a" in aliases
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_columns_case_insensitive(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--columns",
+                " Alias , Topic ",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "handler_a" in result.stdout
+        assert "topic-a" in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_unknown_column_error(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--columns",
+                "alias,nonexistent",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "nonexistent" in result.output
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_empty_app_table(self, mock_import):
+        mock_import.return_value = _build_empty_app()
+        result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
+        assert result.exit_code == 0
+        assert "0 subscribers" in result.stdout
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_header_shows_version(self, mock_import):
+        from fastpubsub.__about__ import __version__
+
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(app, ["inspect", "subscribers", "myapp:app"])
+        assert result.exit_code == 0
+        assert __version__ in result.stdout
+
+
+class TestInspectSubscribersJson:
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_json_output(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["app"] == "myapp:app"
+        assert "version" in data
+        assert len(data["subscribers"]) == 2
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_json_sorted_by_alias(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--format",
+                "json",
+            ],
+        )
+        data = json.loads(result.stdout)
+        aliases = [s["alias"] for s in data["subscribers"]]
+        assert aliases == sorted(aliases)
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_json_with_columns(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--format",
+                "json",
+                "--columns",
+                "alias,topic",
+            ],
+        )
+        data = json.loads(result.stdout)
+        for sub in data["subscribers"]:
+            assert set(sub.keys()) == {"alias", "topic"}
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_json_columns_all(self, mock_import):
+        mock_import.return_value = _build_test_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--format",
+                "json",
+                "--columns",
+                "all",
+            ],
+        )
+        data = json.loads(result.stdout)
+        from fastpubsub.cli.inspect import ALL_COLUMNS
+
+        for sub in data["subscribers"]:
+            assert set(sub.keys()) == set(ALL_COLUMNS)
+
+    @patch("fastpubsub.cli.inspect.import_app")
+    def test_json_empty_app(self, mock_import):
+        mock_import.return_value = _build_empty_app()
+        result = runner.invoke(
+            app,
+            [
+                "inspect",
+                "subscribers",
+                "myapp:app",
+                "--format",
+                "json",
+            ],
+        )
+        data = json.loads(result.stdout)
+        assert data["subscribers"] == []

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -38,7 +38,7 @@ class TestPubSubRouter:
         with pytest.raises(FastPubSubException):
             PubSubRouter(middlewares=321)
 
-    def testget_subscribers(self):
+    def test_get_subscribers(self):
         router = PubSubRouter()
 
         @router.subscriber(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -22,7 +22,7 @@ class TestPubSubRouter:
         async def handler(msg):
             pass
 
-        subscribers = router._get_subscribers()
+        subscribers = router.get_subscribers()
         assert "api.test.alias" in subscribers
 
     def test_include_wrong_type(self):
@@ -38,7 +38,7 @@ class TestPubSubRouter:
         with pytest.raises(FastPubSubException):
             PubSubRouter(middlewares=321)
 
-    def test_get_subscribers(self):
+    def testget_subscribers(self):
         router = PubSubRouter()
 
         @router.subscriber(
@@ -53,7 +53,7 @@ class TestPubSubRouter:
         async def handler2(msg):
             pass
 
-        subscribers = router._get_subscribers()
+        subscribers = router.get_subscribers()
         assert len(subscribers) == 2
         assert "sub1" in subscribers
         assert "sub2" in subscribers
@@ -78,7 +78,7 @@ class TestPubSubRouter:
             pass
 
         with pytest.raises(FastPubSubException):
-            router._get_subscribers()
+            router.get_subscribers()
 
     def test_allow_duplicate_prefix_on_different_aliases(self):
         router = PubSubRouter()
@@ -99,7 +99,7 @@ class TestPubSubRouter:
         async def handler2(msg):
             pass
 
-        subscribers = router._get_subscribers()
+        subscribers = router.get_subscribers()
         assert len(subscribers) == 2
         assert "same.alias_a" in subscribers
         assert "same.alias_b" in subscribers
@@ -133,7 +133,7 @@ class TestPubSubRouter:
             pass
 
         level1_router = PubSubRouter(prefix="level1", routers=(level2_router,))
-        subscribers = level1_router._get_subscribers()
+        subscribers = level1_router.get_subscribers()
         assert "level1.level2.alias" in subscribers
         assert (
             subscribers["level1.level2.alias"].subscription_name

--- a/tests/unit/test_subscriber.py
+++ b/tests/unit/test_subscriber.py
@@ -68,7 +68,7 @@ def subscriber(broker: PubSubBroker) -> Subscriber:
     broker.subscriber(
         "some_sub", topic_name="some_topic", subscription_name="some_sub_name"
     )(some_subscriber_handler)
-    subscribers = broker.router._get_subscribers()
+    subscribers = broker.router.get_subscribers()
     return subscribers.popitem()[1]
 
 
@@ -99,7 +99,7 @@ class TestSubscriber:
         broker.subscriber("sub_c", topic_name="tn", subscription_name="sn")(
             handler_broker
         )
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
 
         subscriber_a = subscribers["a.sub_a"]
         callstack_a = subscriber_a._build_callstack()
@@ -151,7 +151,7 @@ class TestSubscriber:
             "router_handler", topic_name="tn", subscription_name="sn"
         )(handler_b)
 
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
 
         broker_subscriber = subscribers["broker_handler"]
         broker_callstack = broker_subscriber._build_callstack()
@@ -215,7 +215,7 @@ class TestSubscriber:
             handler_b
         )
 
-        subscribers = broker.router._get_subscribers()
+        subscribers = broker.router.get_subscribers()
 
         # Broker Subscriber
         broker_subscriber = subscribers["sub_a"]


### PR DESCRIPTION
## Summary

Adds the `fastpubsub inspect subscribers` CLI command for introspecting subscriber registrations without starting the server or connecting to Google Cloud Pub/Sub.

## What it does

- **New command**: `fastpubsub inspect subscribers <module:app>` lists all registered subscribers in a Rich table
- **Column selection**: `--columns alias,topic` replaces the default columns; `--columns all` shows policy fields (retry, DLT, delivery, lifecycle)
- **Alias filtering**: `--filter 'orders.*'` filters by glob pattern — same patterns as `run --subscribers`, useful as a dry-run
- **JSON output**: `--format json` for scripting and CI pipelines
- **Shared app import**: Extracted `import_app()` utility with improved error messages, shared by both `run` and `inspect`
- **Public API**: `PubSubRouter.get_subscribers()` is now a public method

## Usage examples

```bash
# Default: table with core columns (alias, project, topic, subscription, handler)
fastpubsub inspect subscribers my_project.main:app

# Select specific columns
fastpubsub inspect subscribers my_project.main:app --columns alias,topic,dead_letter_topic

# Show all columns including policy fields
fastpubsub inspect subscribers my_project.main:app --columns all

# Filter by alias pattern (dry-run for run --subscribers)
fastpubsub inspect subscribers my_project.main:app --filter 'orders.*'

# JSON output, pipe to jq
fastpubsub inspect subscribers my_project.main:app --format json | jq '.subscribers[].alias'

# Combine: filter + specific columns + JSON
fastpubsub inspect subscribers my_project.main:app --filter 'platform.**' -c alias,topic -f json
```


## Checklist

- [x] Unit tests added
- [x] Integration tests added
- [x] Documentation updated (user guide + code snippets)
- [x] All 341 unit tests pass
- [x] All 72 doc snippet tests pass
- [x] mypy, ruff, codespell, bandit — all clean
- [x] Follows existing code conventions (Typer, Pydantic, Rich)